### PR TITLE
feat: company identity & liquidity (#26)

### DIFF
--- a/components/status/CashBalancePane.tsx
+++ b/components/status/CashBalancePane.tsx
@@ -18,18 +18,19 @@ interface BalanceRowProps {
 }
 
 function BalanceRow({ currency, amount, indicator, hiddenCount }: BalanceRowProps) {
+  // Ledger layout: fixed-width right-aligned amount column directly beside
+  // the code column, so amounts share one right edge near their labels
+  // instead of stretching to the card edge.
   return (
-    <div className="flex items-center justify-between">
-      <span className="flex items-center gap-2">
-        <span className="text-apxm-text/50 text-xs w-4 shrink-0">{indicator ?? ''}</span>
-        <span className="text-xs text-apxm-text">{currency}</span>
+    <div className="flex items-center gap-2 py-0.5">
+      <span className="text-apxm-text/50 text-xs w-4 shrink-0">{indicator ?? ''}</span>
+      <span className="text-xs text-apxm-text/70 w-9 shrink-0">{currency}</span>
+      <span className="text-xs text-apxm-text tabular-nums w-28 shrink-0 text-right">
+        {formatAmount(amount)}
       </span>
-      <span className="flex items-center gap-2">
-        {hiddenCount !== undefined && hiddenCount > 0 && (
-          <span className="text-xs text-apxm-muted">+{hiddenCount}</span>
-        )}
-        <span className="text-xs text-apxm-text tabular-nums">{formatAmount(amount)}</span>
-      </span>
+      {hiddenCount !== undefined && hiddenCount > 0 && (
+        <span className="text-xs text-apxm-muted">+{hiddenCount}</span>
+      )}
     </div>
   );
 }
@@ -60,8 +61,7 @@ export function CashBalancePane() {
       ? `${company.name} (${company.code})`
       : company.name
     : 'Cash';
-  const visible = expanded ? balances : balances.slice(0, 1);
-  const hiddenCount = balances.length - visible.length;
+  const [primary, ...rest] = balances;
 
   return (
     <Card>
@@ -72,21 +72,37 @@ export function CashBalancePane() {
         <p className="text-xs text-apxm-muted">No balances</p>
       ) : balances.length === 1 ? (
         // Single currency — nothing to expand, render a plain row
-        <BalanceRow currency={balances[0].currency} amount={balances[0].amount} />
+        <div className="pt-3">
+          <BalanceRow currency={balances[0].currency} amount={balances[0].amount} />
+        </div>
       ) : (
+        // flex-col overrides the browser's default vertical centring of
+        // button content: the first row keeps the same offset below the
+        // title in both states, so expanding only grows the list downward.
         <button
           onClick={() => setExpanded(!expanded)}
-          className="w-full min-h-[44px] text-left hover:bg-apxm-accent/30"
+          aria-expanded={expanded}
+          className="w-full min-h-[44px] flex flex-col items-stretch justify-start pt-3 text-left hover:bg-apxm-accent/30"
         >
-          {visible.map((bal, i) => (
-            <BalanceRow
-              key={bal.currency}
-              currency={bal.currency}
-              amount={bal.amount}
-              indicator={i === 0 ? (expanded ? '▼' : '▶') : undefined}
-              hiddenCount={i === 0 && !expanded ? hiddenCount : undefined}
-            />
-          ))}
+          <BalanceRow
+            currency={primary.currency}
+            amount={primary.amount}
+            indicator={expanded ? '▼' : '▶'}
+            hiddenCount={!expanded ? rest.length : undefined}
+          />
+          {/* grid-rows 0fr→1fr animates to the list's natural height
+              (height:auto isn't transitionable); motion-reduce disables it */}
+          <div
+            className={`grid transition-[grid-template-rows,opacity] duration-150 ease-out motion-reduce:transition-none ${
+              expanded ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
+            }`}
+          >
+            <div className="overflow-hidden">
+              {rest.map((bal) => (
+                <BalanceRow key={bal.currency} currency={bal.currency} amount={bal.amount} />
+              ))}
+            </div>
+          </div>
         </button>
       )}
     </Card>

--- a/components/status/CashBalancePane.tsx
+++ b/components/status/CashBalancePane.tsx
@@ -1,37 +1,93 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { Card, SectionHeader } from '../shared';
 import { useBalancesStore } from '../../stores/entities/balances';
+import { useCompanyStore } from '../../stores/company';
+import { primaryCurrencyFor, sortBalances } from '../../lib/currency';
 
 function formatAmount(amount: number): string {
   return Math.round(amount).toLocaleString('en-US');
 }
 
+interface BalanceRowProps {
+  currency: string;
+  amount: number;
+  /** Expand indicator slot — only the first row carries one. */
+  indicator?: string;
+  /** Collapsed-state hint that more currencies exist. */
+  hiddenCount?: number;
+}
+
+function BalanceRow({ currency, amount, indicator, hiddenCount }: BalanceRowProps) {
+  return (
+    <div className="flex items-center justify-between">
+      <span className="flex items-center gap-2">
+        <span className="text-apxm-text/50 text-xs w-4 shrink-0">{indicator ?? ''}</span>
+        <span className="text-xs text-apxm-text">{currency}</span>
+      </span>
+      <span className="flex items-center gap-2">
+        {hiddenCount !== undefined && hiddenCount > 0 && (
+          <span className="text-xs text-apxm-muted">+{hiddenCount}</span>
+        )}
+        <span className="text-xs text-apxm-text tabular-nums">{formatAmount(amount)}</span>
+      </span>
+    </div>
+  );
+}
+
+/**
+ * Company identity + liquidity pane.
+ * Header: company name + code (falls back to "Cash" until COMPANY_DATA arrives).
+ * Collapsed: primary-currency balance on one line with a +N hint.
+ * Expanded (tap): full list — ECD filtered, primary currency first, rest alphabetical.
+ */
 export function CashBalancePane() {
   const fetched = useBalancesStore((s) => s.fetched);
   const entities = useBalancesStore((s) => s.entities);
+  const company = useCompanyStore((s) => s.company);
+  const [expanded, setExpanded] = useState(false);
+
   const balances = useMemo(
-    () => Array.from(entities.values())
-      .filter((b) => b.currency !== 'ECD')
-      .sort((a, b) => a.currency.localeCompare(b.currency)),
-    [entities]
+    () =>
+      sortBalances(
+        Array.from(entities.values()),
+        company ? primaryCurrencyFor(company.countryId) : null
+      ),
+    [entities, company]
   );
+
+  const title = company
+    ? company.code
+      ? `${company.name} (${company.code})`
+      : company.name
+    : 'Cash';
+  const visible = expanded ? balances : balances.slice(0, 1);
+  const hiddenCount = balances.length - visible.length;
 
   return (
     <Card>
-      <SectionHeader title="Cash" />
+      <SectionHeader title={title} />
       {!fetched ? (
         <p className="text-xs text-apxm-muted animate-pulse">Loading balances...</p>
+      ) : balances.length === 0 ? (
+        <p className="text-xs text-apxm-muted">No balances</p>
+      ) : balances.length === 1 ? (
+        // Single currency — nothing to expand, render a plain row
+        <BalanceRow currency={balances[0].currency} amount={balances[0].amount} />
       ) : (
-        <div>
-          {balances.map((bal) => (
-            <div key={bal.currency} className="flex items-center justify-between">
-              <span className="text-xs text-apxm-text">{bal.currency}</span>
-              <span className="text-xs text-apxm-text tabular-nums">
-                {formatAmount(bal.amount)}
-              </span>
-            </div>
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="w-full min-h-[44px] text-left hover:bg-apxm-accent/30"
+        >
+          {visible.map((bal, i) => (
+            <BalanceRow
+              key={bal.currency}
+              currency={bal.currency}
+              amount={bal.amount}
+              indicator={i === 0 ? (expanded ? '▼' : '▶') : undefined}
+              hiddenCount={i === 0 && !expanded ? hiddenCount : undefined}
+            />
           ))}
-        </div>
+        </button>
       )}
     </Card>
   );

--- a/lib/__tests__/currency.test.ts
+++ b/lib/__tests__/currency.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { primaryCurrencyFor, sortBalances } from '../currency';
+import type { PrunApi } from '../../types/prun-api';
+
+function balance(currency: string, amount = 1000): PrunApi.CurrencyAmount {
+  return { currency, amount };
+}
+
+describe('primaryCurrencyFor', () => {
+  it('maps known faction countryIds to their currency', () => {
+    expect(primaryCurrencyFor('AI')).toBe('AIC');
+    expect(primaryCurrencyFor('CI')).toBe('CIS');
+    expect(primaryCurrencyFor('IC')).toBe('ICA');
+    expect(primaryCurrencyFor('NC')).toBe('NCC');
+  });
+
+  it('returns null for unknown countryIds', () => {
+    expect(primaryCurrencyFor('XX')).toBeNull();
+    expect(primaryCurrencyFor('')).toBeNull();
+  });
+});
+
+describe('sortBalances', () => {
+  it('filters out ECD', () => {
+    const result = sortBalances([balance('ECD'), balance('AIC')], null);
+    expect(result.map((b) => b.currency)).toEqual(['AIC']);
+  });
+
+  it('puts the primary currency first, rest alphabetical', () => {
+    const result = sortBalances(
+      [balance('AIC'), balance('NCC'), balance('CIS'), balance('ICA')],
+      'NCC'
+    );
+    expect(result.map((b) => b.currency)).toEqual(['NCC', 'AIC', 'CIS', 'ICA']);
+  });
+
+  it('falls back to alphabetical when primary is null (unresolved countryId)', () => {
+    const result = sortBalances(
+      [balance('NCC'), balance('AIC'), balance('ICA')],
+      null
+    );
+    expect(result.map((b) => b.currency)).toEqual(['AIC', 'ICA', 'NCC']);
+  });
+
+  it('falls back to alphabetical when the primary currency has no balance', () => {
+    const result = sortBalances([balance('NCC'), balance('CIS')], 'AIC');
+    expect(result.map((b) => b.currency)).toEqual(['CIS', 'NCC']);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [balance('NCC'), balance('AIC')];
+    sortBalances(input, null);
+    expect(input.map((b) => b.currency)).toEqual(['NCC', 'AIC']);
+  });
+});

--- a/lib/currency.ts
+++ b/lib/currency.ts
@@ -1,0 +1,36 @@
+import type { PrunApi } from '../types/prun-api';
+
+/**
+ * Faction countryId → primary currency.
+ * Lifted from the archived desktop bridge (desktop-view-archive-20260606).
+ * The countryId keys are unverified against live WS data (issue #26) — an
+ * unmapped countryId returns null, which degrades to alphabetical ordering.
+ */
+const COUNTRY_CURRENCY: Record<string, string> = {
+  AI: 'AIC',
+  CI: 'CIS',
+  IC: 'ICA',
+  NC: 'NCC',
+};
+
+export function primaryCurrencyFor(countryId: string): string | null {
+  return COUNTRY_CURRENCY[countryId] ?? null;
+}
+
+/**
+ * Display order for the liquidity list: ECD filtered out (legacy currency,
+ * not spendable), the company's primary currency first, remaining
+ * currencies alphabetical.
+ */
+export function sortBalances(
+  balances: PrunApi.CurrencyAmount[],
+  primaryCurrency: string | null
+): PrunApi.CurrencyAmount[] {
+  return balances
+    .filter((b) => b.currency !== 'ECD')
+    .sort((a, b) => {
+      if (a.currency === primaryCurrency) return -1;
+      if (b.currency === primaryCurrency) return 1;
+      return a.currency.localeCompare(b.currency);
+    });
+}

--- a/stores/__tests__/message-handlers.test.ts
+++ b/stores/__tests__/message-handlers.test.ts
@@ -23,6 +23,7 @@ import {
   createProductionOrder,
 } from '../../__tests__/fixtures/factories';
 import { useSiteSourceStore } from '../site-data-sources';
+import { useCompanyStore } from '../company';
 
 function dispatchMessage(messageType: string, payload: unknown): void {
   const msg: ProcessedMessage = {
@@ -39,6 +40,7 @@ describe('message-handlers', () => {
   beforeEach(() => {
     clearAllEntityStores();
     useSiteSourceStore.getState().clear();
+    useCompanyStore.getState().clear();
     useConnectionStore.setState({
       connected: false,
       lastMessageTimestamp: null,
@@ -115,6 +117,19 @@ describe('message-handlers', () => {
       dispatchMessage('CLIENT_CONNECTION_OPENED', {});
 
       expect(useSiteSourceStore.getState().entries.size).toBe(0);
+    });
+
+    it('clears company identity on reconnection', () => {
+      // First connection
+      dispatchMessage('CLIENT_CONNECTION_OPENED', {});
+
+      useCompanyStore.getState().setCompany({ name: 'Test Co', code: 'TST', countryId: 'NC' });
+      expect(useCompanyStore.getState().company).not.toBeNull();
+
+      // Reconnection — company re-arrives via COMPANY_DATA, so clear is safe
+      dispatchMessage('CLIENT_CONNECTION_OPENED', {});
+
+      expect(useCompanyStore.getState().company).toBeNull();
     });
 
     it('increments reconnect count', () => {
@@ -405,6 +420,44 @@ describe('message-handlers', () => {
       dispatchMessage('CONTRACTS_CONTRACTS', { contracts });
 
       expect(useContractsStore.getState().entities.size).toBe(2);
+    });
+  });
+
+  describe('COMPANY_DATA', () => {
+    it('populates the company store', () => {
+      dispatchMessage('COMPANY_DATA', { name: 'Test Co', code: 'TST', countryId: 'NC' });
+
+      expect(useCompanyStore.getState().company).toEqual({
+        name: 'Test Co',
+        code: 'TST',
+        countryId: 'NC',
+      });
+    });
+
+    it('defaults missing code and countryId to empty strings', () => {
+      dispatchMessage('COMPANY_DATA', { name: 'Test Co' });
+
+      expect(useCompanyStore.getState().company).toEqual({
+        name: 'Test Co',
+        code: '',
+        countryId: '',
+      });
+    });
+
+    it('discards payloads without a name and leaves the store untouched', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      dispatchMessage('COMPANY_DATA', { code: 'TST' });
+
+      expect(useCompanyStore.getState().company).toBeNull();
+      expect(useConnectionStore.getState().discardedMessages).toBe(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[APXM]',
+        'COMPANY_DATA: unexpected payload structure',
+        expect.anything()
+      );
+
+      warnSpy.mockRestore();
     });
   });
 

--- a/stores/company.ts
+++ b/stores/company.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand';
+
+/**
+ * Company identity from the COMPANY_DATA login message.
+ * Not persisted — repopulated from COMPANY_DATA on every login,
+ * and cleared on reconnect like all other game state.
+ */
+export interface CompanyInfo {
+  name: string;
+  code: string;
+  countryId: string;
+}
+
+interface CompanyState {
+  company: CompanyInfo | null;
+  setCompany: (info: CompanyInfo) => void;
+  clear: () => void;
+}
+
+export const useCompanyStore = create<CompanyState>((set) => ({
+  company: null,
+  setCompany: (company) => set({ company }),
+  clear: () => set({ company: null }),
+}));

--- a/stores/message-handlers.ts
+++ b/stores/message-handlers.ts
@@ -15,6 +15,7 @@ import {
   type WorkforceEntity,
 } from './entities';
 import { useSiteSourceStore } from './site-data-sources';
+import { useCompanyStore } from './company';
 
 type MessageHandler = (msg: ProcessedMessage) => void;
 const typeHandlers = new Map<string, MessageHandler>();
@@ -97,6 +98,9 @@ export function initMessageHandlers(): void {
     if (reconnectCount > 0) {
       clearAllEntityStores();
       useSiteSourceStore.getState().clear();
+      // Not an entity store, so clearAllEntityStores doesn't cover it.
+      // COMPANY_DATA re-arrives with the login dump.
+      useCompanyStore.getState().clear();
     }
     useConnectionStore.getState().incrementReconnectCount();
     useConnectionStore.getState().setConnected(true);
@@ -453,6 +457,31 @@ export function initMessageHandlers(): void {
       }
     } else {
       warn('ACCOUNTING_BOOKINGS: unexpected payload structure', payload);
+      useConnectionStore.getState().incrementDiscarded();
+    }
+  });
+
+  // ============================================================================
+  // Company
+  // ============================================================================
+
+  // Company identity sent on login. name is the only field the UI cannot
+  // degrade without; code/countryId fall back to '' (no code suffix shown,
+  // alphabetical currency ordering).
+  typeHandlers.set('COMPANY_DATA', (msg: ProcessedMessage) => {
+    const payload = extractPayload(msg) as {
+      name?: string;
+      code?: string;
+      countryId?: string;
+    };
+    if (typeof payload?.name === 'string') {
+      useCompanyStore.getState().setCompany({
+        name: payload.name,
+        code: typeof payload.code === 'string' ? payload.code : '',
+        countryId: typeof payload.countryId === 'string' ? payload.countryId : '',
+      });
+    } else {
+      warn('COMPANY_DATA: unexpected payload structure', payload);
       useConnectionStore.getState().incrementDiscarded();
     }
   });


### PR DESCRIPTION
Closes #26.

## What

- **`stores/company.ts`** — company identity store (`{ name, code, countryId }`), lifted from the `desktop-view-archive-20260606` tag with the bridge coupling stripped. Not persisted — repopulated from `COMPANY_DATA` on login, cleared on reconnect.
- **`COMPANY_DATA` handler** in `stores/message-handlers.ts` — boundary-validated (warn + discard on malformed), `code`/`countryId` degrade to `''`.
- **`lib/currency.ts`** — `COUNTRY_CURRENCY` faction map (`AI→AIC, CI→CIS, IC→ICA, NC→NCC`) + `sortBalances` (ECD filtered, primary currency first, rest alphabetical).
- **`CashBalancePane` rework** — header shows company name + code (falls back to "Cash" until `COMPANY_DATA` arrives); collapsed shows the primary-currency balance on one line with a `+N` hint; tap expands to the full liquidity list. Condensed-row refinement credit: [jackinabox86](https://github.com/jackinabox86/APXM).

## Verification

- `npx tsc --noEmit` clean
- 316 tests passing (+11 new: handler populate/default/discard, reconnect clear, currency ordering/fallback)
- Chrome + Firefox builds both succeed

## Outstanding

The `countryId` keys in `COUNTRY_CURRENCY` are **unverified against live WS data** (flagged in the issue). Needs one live session check that your company's primary currency sorts first. A wrong/missing mapping degrades to alphabetical ordering rather than breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)