### PR TITLE
feat: filter state survives tab switches (all views); INF tier tried & removed

### DIFF
--- a/components/views/BasesView.tsx
+++ b/components/views/BasesView.tsx
@@ -9,7 +9,6 @@ const filterLabels: Record<BurnFilter, string> = {
   critical: 'RED',
   warning: 'YELLOW',
   ok: 'GREEN',
-  surplus: 'INF',
   all: 'ALL',
 };
 
@@ -38,7 +37,6 @@ export function BasesView() {
     { id: 'critical', label: filterLabels.critical, count: counts.critical },
     { id: 'warning', label: filterLabels.warning, count: counts.warning },
     { id: 'ok', label: filterLabels.ok, count: counts.ok },
-    { id: 'surplus', label: filterLabels.surplus, count: counts.surplus },
     { id: 'all', label: filterLabels.all, count: counts.all },
   ];
 

--- a/components/views/BasesView.tsx
+++ b/components/views/BasesView.tsx
@@ -1,51 +1,28 @@
-import { useCallback, useState } from 'react';
 import { FilterBar, type FilterOption, DataGate, type RequiredStore } from '../shared';
 import { SiteBurnCard } from '../burn/SiteBurnCard';
 import { useFilteredBurns, type BurnFilter } from './hooks';
 import { useSitesStore } from '../../stores/entities/sites';
+import { useGameState } from '../../stores/gameState';
 
 // UI label mapping: internal type → display
 const filterLabels: Record<BurnFilter, string> = {
   critical: 'RED',
   warning: 'YELLOW',
   ok: 'GREEN',
+  surplus: 'INF',
   all: 'ALL',
 };
-
-// Non-ALL filter values for revert logic
-const individualFilters: BurnFilter[] = ['critical', 'warning', 'ok'];
 
 /**
  * Full burn view showing all sites with filtering by urgency.
  * BURN tab content.
  */
 export function BasesView() {
-  const [activeFilters, setActiveFilters] = useState<Set<BurnFilter>>(new Set(['all']));
+  // Filter selection lives in gameState so it survives tab switches;
+  // the toggle rules (ALL reset, empty→ALL, full-set→ALL) live with it.
+  const activeFilters = useGameState((s) => s.burnFilters);
+  const toggleBurnFilter = useGameState((s) => s.toggleBurnFilter);
   const { summaries, counts } = useFilteredBurns(activeFilters);
-
-  const handleFilterToggle = useCallback((filter: BurnFilter) => {
-    setActiveFilters((prev) => {
-      // Selecting ALL resets to show everything
-      if (filter === 'all') return new Set(['all']);
-
-      const next = new Set(prev);
-      next.delete('all');
-
-      if (next.has(filter)) {
-        next.delete(filter);
-      } else {
-        next.add(filter);
-      }
-
-      // If nothing selected, revert to ALL
-      if (next.size === 0) return new Set(['all']);
-
-      // If all individual filters selected, collapse to ALL
-      if (individualFilters.every((f) => next.has(f))) return new Set(['all']);
-
-      return next;
-    });
-  }, []);
 
   const sitesFetched = useSitesStore((s) => s.fetched);
 
@@ -61,13 +38,14 @@ export function BasesView() {
     { id: 'critical', label: filterLabels.critical, count: counts.critical },
     { id: 'warning', label: filterLabels.warning, count: counts.warning },
     { id: 'ok', label: filterLabels.ok, count: counts.ok },
+    { id: 'surplus', label: filterLabels.surplus, count: counts.surplus },
     { id: 'all', label: filterLabels.all, count: counts.all },
   ];
 
   return (
     <DataGate requiredStores={requiredStores}>
       <div className="space-y-3">
-        <FilterBar options={filterOptions} activeFilters={activeFilters} onChange={handleFilterToggle} />
+        <FilterBar options={filterOptions} activeFilters={activeFilters} onChange={toggleBurnFilter} />
 
         {summaries.length === 0 ? (
           <p className="text-sm text-apxm-muted py-4 text-center">

--- a/components/views/ContractsView.tsx
+++ b/components/views/ContractsView.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useState } from 'react';
 import { FilterBar, type FilterOption, DataGate, type RequiredStore } from '../shared';
 import { ContractCard } from '../contracts';
 import { useContractDetails, type ContractFilter } from './hooks';
 import { useContractsStore } from '../../stores/entities/contracts';
+import { useGameState } from '../../stores/gameState';
 
 // UI labels for filter options
 const filterLabels: Record<ContractFilter, string> = {
@@ -11,36 +11,15 @@ const filterLabels: Record<ContractFilter, string> = {
   fulfilled: 'FULFILLED',
 };
 
-// Non-ALL filter values for revert logic
-const individualFilters: ContractFilter[] = ['active', 'fulfilled'];
-
 /**
  * Full contracts view showing all contracts with filtering.
  * CONTRACTS tab content.
  */
 export function ContractsView() {
-  const [activeFilters, setActiveFilters] = useState<Set<ContractFilter>>(new Set(['active']));
+  // Filter selection lives in gameState so it survives tab switches
+  const activeFilters = useGameState((s) => s.contractFilters);
+  const toggleContractFilter = useGameState((s) => s.toggleContractFilter);
   const { contracts, counts } = useContractDetails(activeFilters);
-
-  const handleFilterToggle = useCallback((filter: ContractFilter) => {
-    setActiveFilters((prev) => {
-      if (filter === 'all') return new Set(['all']);
-
-      const next = new Set(prev);
-      next.delete('all');
-
-      if (next.has(filter)) {
-        next.delete(filter);
-      } else {
-        next.add(filter);
-      }
-
-      if (next.size === 0) return new Set(['all']);
-      if (individualFilters.every((f) => next.has(f))) return new Set(['all']);
-
-      return next;
-    });
-  }, []);
 
   const contractsFetched = useContractsStore((s) => s.fetched);
 
@@ -58,7 +37,7 @@ export function ContractsView() {
   return (
     <DataGate requiredStores={requiredStores}>
       <div className="space-y-3">
-        <FilterBar options={filterOptions} activeFilters={activeFilters} onChange={handleFilterToggle} />
+        <FilterBar options={filterOptions} activeFilters={activeFilters} onChange={toggleContractFilter} />
 
         {contracts.length === 0 ? (
           <p className="text-sm text-apxm-muted py-4 text-center">

--- a/components/views/FleetView.tsx
+++ b/components/views/FleetView.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useState } from 'react';
 import { FilterBar, type FilterOption, DataGate, type RequiredStore } from '../shared';
 import { ShipCard } from '../fleet';
 import { useFleetDetails, type FleetFilter } from './hooks';
 import { useShipsStore } from '../../stores/entities/ships';
+import { useGameState } from '../../stores/gameState';
 
 // UI labels for filter options
 const filterLabels: Record<FleetFilter, string> = {
@@ -11,36 +11,15 @@ const filterLabels: Record<FleetFilter, string> = {
   'in-transit': 'IN TRANSIT',
 };
 
-// Non-ALL filter values for revert logic
-const individualFilters: FleetFilter[] = ['idle', 'in-transit'];
-
 /**
  * Full fleet view showing all ships with filtering.
  * FLEET tab content.
  */
 export function FleetView() {
-  const [activeFilters, setActiveFilters] = useState<Set<FleetFilter>>(new Set(['all']));
+  // Filter selection lives in gameState so it survives tab switches
+  const activeFilters = useGameState((s) => s.fleetFilters);
+  const toggleFleetFilter = useGameState((s) => s.toggleFleetFilter);
   const { ships, counts } = useFleetDetails(activeFilters);
-
-  const handleFilterToggle = useCallback((filter: FleetFilter) => {
-    setActiveFilters((prev) => {
-      if (filter === 'all') return new Set(['all']);
-
-      const next = new Set(prev);
-      next.delete('all');
-
-      if (next.has(filter)) {
-        next.delete(filter);
-      } else {
-        next.add(filter);
-      }
-
-      if (next.size === 0) return new Set(['all']);
-      if (individualFilters.every((f) => next.has(f))) return new Set(['all']);
-
-      return next;
-    });
-  }, []);
 
   const shipsFetched = useShipsStore((s) => s.fetched);
 
@@ -58,7 +37,7 @@ export function FleetView() {
   return (
     <DataGate requiredStores={requiredStores}>
       <div className="space-y-3">
-        <FilterBar options={filterOptions} activeFilters={activeFilters} onChange={handleFilterToggle} />
+        <FilterBar options={filterOptions} activeFilters={activeFilters} onChange={toggleFleetFilter} />
 
         {ships.length === 0 ? (
           <p className="text-sm text-apxm-muted py-4 text-center">

--- a/components/views/hooks/__tests__/useFilteredBurns.test.ts
+++ b/components/views/hooks/__tests__/useFilteredBurns.test.ts
@@ -2,15 +2,17 @@ import { describe, it, expect } from 'vitest';
 import { getFilterForUrgency } from '../useFilteredBurns';
 
 describe('getFilterForUrgency', () => {
-  it('maps each urgency tier to its own filter', () => {
+  it('maps red/yellow/green urgencies to their own filter', () => {
     expect(getFilterForUrgency('critical')).toBe('critical');
     expect(getFilterForUrgency('warning')).toBe('warning');
     expect(getFilterForUrgency('ok')).toBe('ok');
-    // Regression: surplus used to collapse into 'ok' (issue #24)
-    expect(getFilterForUrgency('surplus')).toBe('surplus');
   });
 
-  it("maps missing burn data to 'ok' — nothing burning is not surplus", () => {
+  it("folds surplus into 'ok' — per-site mostUrgent never lands on surplus, so INF gets no tier (#24)", () => {
+    expect(getFilterForUrgency('surplus')).toBe('ok');
+  });
+
+  it("maps missing burn data to 'ok'", () => {
     expect(getFilterForUrgency(undefined)).toBe('ok');
   });
 });

--- a/components/views/hooks/__tests__/useFilteredBurns.test.ts
+++ b/components/views/hooks/__tests__/useFilteredBurns.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { getFilterForUrgency } from '../useFilteredBurns';
+
+describe('getFilterForUrgency', () => {
+  it('maps each urgency tier to its own filter', () => {
+    expect(getFilterForUrgency('critical')).toBe('critical');
+    expect(getFilterForUrgency('warning')).toBe('warning');
+    expect(getFilterForUrgency('ok')).toBe('ok');
+    // Regression: surplus used to collapse into 'ok' (issue #24)
+    expect(getFilterForUrgency('surplus')).toBe('surplus');
+  });
+
+  it("maps missing burn data to 'ok' — nothing burning is not surplus", () => {
+    expect(getFilterForUrgency(undefined)).toBe('ok');
+  });
+});

--- a/components/views/hooks/useContractDetails.ts
+++ b/components/views/hooks/useContractDetails.ts
@@ -2,7 +2,9 @@ import { useMemo } from 'react';
 import { useContractsStore } from '../../../stores/entities/contracts';
 import type { PrunApi } from '../../../types/prun-api';
 
-export type ContractFilter = 'all' | 'active' | 'fulfilled';
+import type { ContractFilter } from '../../../stores/gameState';
+
+export type { ContractFilter };
 
 // Contract statuses considered "active" (need attention)
 const ACTIVE_STATUSES: PrunApi.ContractStatus[] = ['OPEN', 'CLOSED', 'PARTIALLY_FULFILLED'];

--- a/components/views/hooks/useFilteredBurns.ts
+++ b/components/views/hooks/useFilteredBurns.ts
@@ -1,8 +1,9 @@
 import { useMemo } from 'react';
 import { useSiteBurns, sortByUrgency } from '../../burn/useSiteBurns';
 import type { SiteBurnSummary, Urgency } from '../../../core/burn';
+import type { BurnFilter } from '../../../stores/gameState';
 
-export type BurnFilter = 'all' | 'critical' | 'warning' | 'ok';
+export type { BurnFilter };
 
 export interface FilteredBurnsResult {
   summaries: SiteBurnSummary[];
@@ -11,13 +12,10 @@ export interface FilteredBurnsResult {
 
 /**
  * Maps internal urgency to display filter.
- * Sites with mostUrgent of that urgency level.
+ * Sites with no burn data land in 'ok' — "nothing burning" is not surplus.
  */
-function getFilterForUrgency(urgency: Urgency | undefined): BurnFilter {
-  if (!urgency) return 'ok';
-  if (urgency === 'critical') return 'critical';
-  if (urgency === 'warning') return 'warning';
-  return 'ok'; // 'ok' and 'surplus' both map to 'ok' filter
+export function getFilterForUrgency(urgency: Urgency | undefined): BurnFilter {
+  return urgency ?? 'ok';
 }
 
 /**
@@ -35,6 +33,7 @@ export function useFilteredBurns(activeFilters: ReadonlySet<BurnFilter>): Filter
       critical: 0,
       warning: 0,
       ok: 0,
+      surplus: 0,
     };
 
     for (const summary of sorted) {

--- a/components/views/hooks/useFilteredBurns.ts
+++ b/components/views/hooks/useFilteredBurns.ts
@@ -12,10 +12,13 @@ export interface FilteredBurnsResult {
 
 /**
  * Maps internal urgency to display filter.
- * Sites with no burn data land in 'ok' — "nothing burning" is not surplus.
+ * Surplus folds into 'ok': per-site mostUrgent never lands on surplus
+ * (workforce consumables always burn), so it gets no tier of its own.
+ * Sites with no burn data also land in 'ok'.
  */
 export function getFilterForUrgency(urgency: Urgency | undefined): BurnFilter {
-  return urgency ?? 'ok';
+  if (!urgency || urgency === 'surplus') return 'ok';
+  return urgency;
 }
 
 /**
@@ -33,7 +36,6 @@ export function useFilteredBurns(activeFilters: ReadonlySet<BurnFilter>): Filter
       critical: 0,
       warning: 0,
       ok: 0,
-      surplus: 0,
     };
 
     for (const summary of sorted) {

--- a/components/views/hooks/useFleetDetails.ts
+++ b/components/views/hooks/useFleetDetails.ts
@@ -6,7 +6,9 @@ import { getDestinationName, formatEta, getCurrentLocation } from '../../../lib/
 import { useTick } from '../../../lib/use-tick';
 import type { PrunApi } from '../../../types/prun-api';
 
-export type FleetFilter = 'all' | 'idle' | 'in-transit';
+import type { FleetFilter } from '../../../stores/gameState';
+
+export type { FleetFilter };
 
 export type FlightState = 'IDL' | 'ARR' | 'TRN' | 'DEP' | 'ORB';
 

--- a/stores/__tests__/gameState.test.ts
+++ b/stores/__tests__/gameState.test.ts
@@ -55,8 +55,8 @@ describe('gameState store', () => {
 
     it('supports multi-select of tiers', () => {
       toggle('critical');
-      toggle('surplus');
-      expect(filters()).toEqual(['critical', 'surplus']);
+      toggle('ok');
+      expect(filters()).toEqual(['critical', 'ok']);
     });
 
     it('deselecting the last tier reverts to ALL', () => {
@@ -65,11 +65,10 @@ describe('gameState store', () => {
       expect(filters()).toEqual(['all']);
     });
 
-    it('selecting all four tiers collapses to ALL', () => {
+    it('selecting all three tiers collapses to ALL', () => {
       toggle('critical');
       toggle('warning');
       toggle('ok');
-      toggle('surplus');
       expect(filters()).toEqual(['all']);
     });
 

--- a/stores/__tests__/gameState.test.ts
+++ b/stores/__tests__/gameState.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { useGameState } from '../gameState';
+import { useGameState, type BurnFilter } from '../gameState';
 
 /**
  * gameState store tests.
@@ -12,6 +12,7 @@ describe('gameState store', () => {
     useGameState.setState({
       overlayVisible: true,
       debugMode: false,
+      burnFilters: new Set<BurnFilter>(['all']),
     });
   });
 
@@ -36,6 +37,47 @@ describe('gameState store', () => {
     it('updates debug mode', () => {
       useGameState.getState().setDebugMode(true);
       expect(useGameState.getState().debugMode).toBe(true);
+    });
+  });
+
+  describe('toggleBurnFilter', () => {
+    const filters = () => [...useGameState.getState().burnFilters].sort();
+    const toggle = (f: BurnFilter) => useGameState.getState().toggleBurnFilter(f);
+
+    it('defaults to ALL', () => {
+      expect(filters()).toEqual(['all']);
+    });
+
+    it('selecting a tier replaces ALL with that tier', () => {
+      toggle('critical');
+      expect(filters()).toEqual(['critical']);
+    });
+
+    it('supports multi-select of tiers', () => {
+      toggle('critical');
+      toggle('surplus');
+      expect(filters()).toEqual(['critical', 'surplus']);
+    });
+
+    it('deselecting the last tier reverts to ALL', () => {
+      toggle('warning');
+      toggle('warning');
+      expect(filters()).toEqual(['all']);
+    });
+
+    it('selecting all four tiers collapses to ALL', () => {
+      toggle('critical');
+      toggle('warning');
+      toggle('ok');
+      toggle('surplus');
+      expect(filters()).toEqual(['all']);
+    });
+
+    it('selecting ALL resets any tier selection', () => {
+      toggle('critical');
+      toggle('ok');
+      toggle('all');
+      expect(filters()).toEqual(['all']);
     });
   });
 });

--- a/stores/__tests__/gameState.test.ts
+++ b/stores/__tests__/gameState.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { useGameState, type BurnFilter } from '../gameState';
+import {
+  useGameState,
+  type BurnFilter,
+  type FleetFilter,
+  type ContractFilter,
+} from '../gameState';
 
 /**
  * gameState store tests.
@@ -13,6 +18,8 @@ describe('gameState store', () => {
       overlayVisible: true,
       debugMode: false,
       burnFilters: new Set<BurnFilter>(['all']),
+      fleetFilters: new Set<FleetFilter>(['all']),
+      contractFilters: new Set<ContractFilter>(['active']),
     });
   });
 
@@ -77,6 +84,40 @@ describe('gameState store', () => {
       toggle('ok');
       toggle('all');
       expect(filters()).toEqual(['all']);
+    });
+  });
+
+  describe('toggleFleetFilter', () => {
+    const filters = () => [...useGameState.getState().fleetFilters].sort();
+
+    it('defaults to ALL', () => {
+      expect(filters()).toEqual(['all']);
+    });
+
+    it('applies the shared toggle rules', () => {
+      useGameState.getState().toggleFleetFilter('idle');
+      expect(filters()).toEqual(['idle']);
+
+      // Selecting both individual filters collapses to ALL
+      useGameState.getState().toggleFleetFilter('in-transit');
+      expect(filters()).toEqual(['all']);
+    });
+  });
+
+  describe('toggleContractFilter', () => {
+    const filters = () => [...useGameState.getState().contractFilters].sort();
+
+    it('defaults to ACTIVE — fulfilled contracts are history', () => {
+      expect(filters()).toEqual(['active']);
+    });
+
+    it('applies the shared toggle rules', () => {
+      // Deselecting the default reverts to ALL
+      useGameState.getState().toggleContractFilter('active');
+      expect(filters()).toEqual(['all']);
+
+      useGameState.getState().toggleContractFilter('fulfilled');
+      expect(filters()).toEqual(['fulfilled']);
     });
   });
 });

--- a/stores/gameState.ts
+++ b/stores/gameState.ts
@@ -9,11 +9,16 @@ import type { Urgency } from '../core/burn';
 
 export type TabId = 'status' | 'fleet' | 'bases' | 'contracts' | 'settings';
 
-/** Burn view filter: one of the four urgency tiers, or 'all'. */
-export type BurnFilter = Urgency | 'all';
+/**
+ * Burn view filter tiers. 'surplus' is deliberately excluded: a site's
+ * mostUrgent can never be surplus because workforce consumables always
+ * burn on every base, so an INF tier matches nothing (tried and removed
+ * 2026-06-10, see #24). Surplus exists per-material, not per-site.
+ */
+export type BurnFilter = Exclude<Urgency, 'surplus'> | 'all';
 
 // Non-ALL filter values, used by the toggle collapse/revert rules
-const individualBurnFilters: BurnFilter[] = ['critical', 'warning', 'ok', 'surplus'];
+const individualBurnFilters: BurnFilter[] = ['critical', 'warning', 'ok'];
 
 interface GameState {
   overlayVisible: boolean;

--- a/stores/gameState.ts
+++ b/stores/gameState.ts
@@ -16,23 +16,59 @@ export type TabId = 'status' | 'fleet' | 'bases' | 'contracts' | 'settings';
  * 2026-06-10, see #24). Surplus exists per-material, not per-site.
  */
 export type BurnFilter = Exclude<Urgency, 'surplus'> | 'all';
+export type FleetFilter = 'idle' | 'in-transit' | 'all';
+export type ContractFilter = 'active' | 'fulfilled' | 'all';
 
-// Non-ALL filter values, used by the toggle collapse/revert rules
-const individualBurnFilters: BurnFilter[] = ['critical', 'warning', 'ok'];
+// Non-ALL filter values per view, used by the toggle collapse/revert rules
+const individualBurnFilters: readonly BurnFilter[] = ['critical', 'warning', 'ok'];
+const individualFleetFilters: readonly FleetFilter[] = ['idle', 'in-transit'];
+const individualContractFilters: readonly ContractFilter[] = ['active', 'fulfilled'];
+
+/**
+ * Shared filter-toggle rules for all view filter bars:
+ * selecting ALL resets; deselecting the last filter reverts to ALL;
+ * selecting every individual filter collapses to ALL.
+ */
+function toggleFilterSelection<T extends string>(
+  current: ReadonlySet<T | 'all'>,
+  filter: T | 'all',
+  individualFilters: readonly T[]
+): ReadonlySet<T | 'all'> {
+  if (filter === 'all') return new Set<T | 'all'>(['all']);
+
+  const next = new Set(current);
+  next.delete('all');
+
+  if (next.has(filter)) {
+    next.delete(filter);
+  } else {
+    next.add(filter);
+  }
+
+  if (next.size === 0) return new Set<T | 'all'>(['all']);
+  if (individualFilters.every((f) => next.has(f))) return new Set<T | 'all'>(['all']);
+
+  return next;
+}
 
 interface GameState {
   overlayVisible: boolean;
   debugMode: boolean;
   apexVisible: boolean;
   activeTab: TabId;
-  // Session-scoped (not persisted): survives tab switches, resets on reload.
-  // A filter that stuck across days would silently hide bases.
+  // Filter selections are session-scoped (not persisted): they survive tab
+  // switches but reset on reload. A filter that stuck across days would
+  // silently hide bases/ships/contracts.
   burnFilters: ReadonlySet<BurnFilter>;
+  fleetFilters: ReadonlySet<FleetFilter>;
+  contractFilters: ReadonlySet<ContractFilter>;
   setOverlayVisible: (visible: boolean) => void;
   setDebugMode: (debug: boolean) => void;
   setApexVisible: (visible: boolean) => void;
   setActiveTab: (tab: TabId) => void;
   toggleBurnFilter: (filter: BurnFilter) => void;
+  toggleFleetFilter: (filter: FleetFilter) => void;
+  toggleContractFilter: (filter: ContractFilter) => void;
 }
 
 export const useGameState = create<GameState>((set) => ({
@@ -41,32 +77,23 @@ export const useGameState = create<GameState>((set) => ({
   apexVisible: false,
   activeTab: 'status',
   burnFilters: new Set<BurnFilter>(['all']),
+  fleetFilters: new Set<FleetFilter>(['all']),
+  // Contracts default to ACTIVE — fulfilled contracts are history
+  contractFilters: new Set<ContractFilter>(['active']),
   setOverlayVisible: (overlayVisible) => set({ overlayVisible }),
   setDebugMode: (debugMode) => set({ debugMode }),
   setApexVisible: (apexVisible) => set({ apexVisible }),
   setActiveTab: (activeTab) => set({ activeTab }),
   toggleBurnFilter: (filter) =>
-    set((state) => {
-      // Selecting ALL resets to show everything
-      if (filter === 'all') return { burnFilters: new Set<BurnFilter>(['all']) };
-
-      const next = new Set(state.burnFilters);
-      next.delete('all');
-
-      if (next.has(filter)) {
-        next.delete(filter);
-      } else {
-        next.add(filter);
-      }
-
-      // If nothing selected, revert to ALL
-      if (next.size === 0) return { burnFilters: new Set<BurnFilter>(['all']) };
-
-      // If all individual filters selected, collapse to ALL
-      if (individualBurnFilters.every((f) => next.has(f))) {
-        return { burnFilters: new Set<BurnFilter>(['all']) };
-      }
-
-      return { burnFilters: next };
-    }),
+    set((state) => ({
+      burnFilters: toggleFilterSelection(state.burnFilters, filter, individualBurnFilters),
+    })),
+  toggleFleetFilter: (filter) =>
+    set((state) => ({
+      fleetFilters: toggleFilterSelection(state.fleetFilters, filter, individualFleetFilters),
+    })),
+  toggleContractFilter: (filter) =>
+    set((state) => ({
+      contractFilters: toggleFilterSelection(state.contractFilters, filter, individualContractFilters),
+    })),
 }));

--- a/stores/gameState.ts
+++ b/stores/gameState.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import type { Urgency } from '../core/burn';
 
 /**
  * UI-related game state.
@@ -8,15 +9,25 @@ import { create } from 'zustand';
 
 export type TabId = 'status' | 'fleet' | 'bases' | 'contracts' | 'settings';
 
+/** Burn view filter: one of the four urgency tiers, or 'all'. */
+export type BurnFilter = Urgency | 'all';
+
+// Non-ALL filter values, used by the toggle collapse/revert rules
+const individualBurnFilters: BurnFilter[] = ['critical', 'warning', 'ok', 'surplus'];
+
 interface GameState {
   overlayVisible: boolean;
   debugMode: boolean;
   apexVisible: boolean;
   activeTab: TabId;
+  // Session-scoped (not persisted): survives tab switches, resets on reload.
+  // A filter that stuck across days would silently hide bases.
+  burnFilters: ReadonlySet<BurnFilter>;
   setOverlayVisible: (visible: boolean) => void;
   setDebugMode: (debug: boolean) => void;
   setApexVisible: (visible: boolean) => void;
   setActiveTab: (tab: TabId) => void;
+  toggleBurnFilter: (filter: BurnFilter) => void;
 }
 
 export const useGameState = create<GameState>((set) => ({
@@ -24,8 +35,33 @@ export const useGameState = create<GameState>((set) => ({
   debugMode: false,
   apexVisible: false,
   activeTab: 'status',
+  burnFilters: new Set<BurnFilter>(['all']),
   setOverlayVisible: (overlayVisible) => set({ overlayVisible }),
   setDebugMode: (debugMode) => set({ debugMode }),
   setApexVisible: (apexVisible) => set({ apexVisible }),
   setActiveTab: (activeTab) => set({ activeTab }),
+  toggleBurnFilter: (filter) =>
+    set((state) => {
+      // Selecting ALL resets to show everything
+      if (filter === 'all') return { burnFilters: new Set<BurnFilter>(['all']) };
+
+      const next = new Set(state.burnFilters);
+      next.delete('all');
+
+      if (next.has(filter)) {
+        next.delete(filter);
+      } else {
+        next.add(filter);
+      }
+
+      // If nothing selected, revert to ALL
+      if (next.size === 0) return { burnFilters: new Set<BurnFilter>(['all']) };
+
+      // If all individual filters selected, collapse to ALL
+      if (individualBurnFilters.every((f) => next.has(f))) {
+        return { burnFilters: new Set<BurnFilter>(['all']) };
+      }
+
+      return { burnFilters: next };
+    }),
 }));


### PR DESCRIPTION
Partial #24 (filter-polish items) + the adjacent fleet/contracts fix.

## What

- **Filter state survives tab switches — all three views.** Burn, fleet, and contract filter selections move from per-view `useState` into the `gameState` store. The toggle rules (ALL resets; empty selection reverts to ALL; all-individuals-selected collapses to ALL) were copy-pasted in all three views — now one shared, tested `toggleFilterSelection` helper. Session-scoped on purpose: not persisted to `browser.storage`, so a days-old filter can't silently hide bases/ships/contracts on next launch. Contracts keep their ACTIVE default.
- **INF/surplus tier: tried, then removed after live testing** (commits 1–2). A site's `mostUrgent` can never be surplus because every base burns workforce consumables — the INF tier structurally matches zero bases. Surplus stays a per-material concept; at site level it folds into GREEN. The reason is encoded at the `BurnFilter` type and the urgency mapping so the tier doesn't get re-proposed. Filter bar remains **RED / YELLOW / GREEN / ALL**.
- Views slim to pure rendering; toggle rules unit-tested.

## Verification

- `npx tsc --noEmit` clean
- 329 tests passing (toggle rules incl. per-view defaults, urgency mapping incl. surplus-folds-into-ok with the domain reason)
- Chrome + Firefox builds both succeed; burn filter persistence + RED/YELLOW/GREEN/ALL verified on a live dev build (fleet/contracts persistence pending the same check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)