### PR TITLE
feat: BURN / REPAIR / PROD base status (#24)

### DIFF
--- a/components/burn/BaseStatusTile.tsx
+++ b/components/burn/BaseStatusTile.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from 'react';
+
+export type TileTone = 'critical' | 'warning' | 'ok' | 'muted';
+
+const toneClasses: Record<TileTone, string> = {
+  critical: 'bg-status-critical/15 text-status-critical',
+  warning: 'bg-status-warning/15 text-status-warning',
+  ok: 'bg-status-ok/15 text-status-ok',
+  muted: 'bg-apxm-bg text-apxm-muted',
+};
+
+/**
+ * Compact labelled status tile for base card headers (BURN / REPAIR / PROD).
+ * Layout inspired by jackinabox86's APXM fork (https://github.com/jackinabox86/APXM).
+ */
+export function BaseStatusTile({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: ReactNode;
+  tone: TileTone;
+}) {
+  return (
+    <div
+      className={`flex flex-col items-center justify-center px-1.5 py-1 min-w-[3.25rem] ${toneClasses[tone]}`}
+    >
+      <span className="text-[9px] uppercase tracking-wide opacity-80">{label}</span>
+      <span className="text-xs font-semibold">{value}</span>
+    </div>
+  );
+}

--- a/components/burn/BurnSummaryList.tsx
+++ b/components/burn/BurnSummaryList.tsx
@@ -1,6 +1,9 @@
+import { useMemo } from 'react';
 import { useSiteBurns, sortByUrgency } from './useSiteBurns';
 import { SiteBurnCard } from './SiteBurnCard';
 import { DataSourceBadge } from './DataSourceBadge';
+import { useRepairStatus } from './useRepairStatus';
+import { useProdStatuses } from './useProdStatus';
 import { useSettingsStore } from '../../stores/settings';
 import {
   useSiteSourceStore,
@@ -19,6 +22,12 @@ interface BurnSummaryListProps {
 export function BurnSummaryList({ expandFirst = true }: BurnSummaryListProps) {
   const summaries = useSiteBurns();
   const sorted = sortByUrgency(summaries);
+  const repairStatuses = useRepairStatus();
+  const prodStatuses = useProdStatuses();
+  const repairBySite = useMemo(
+    () => new Map(repairStatuses.map((r) => [r.siteId, r])),
+    [repairStatuses]
+  );
 
   // Derive data source from per-site entries (weakest-link across all sites)
   const siteEntries = useSiteSourceStore((s) => s.entries);
@@ -53,6 +62,8 @@ export function BurnSummaryList({ expandFirst = true }: BurnSummaryListProps) {
         <SiteBurnCard
           key={summary.siteId}
           summary={summary}
+          repairAgeDays={repairBySite.get(summary.siteId)?.oldestBuildingAgeDays ?? null}
+          prodStatus={prodStatuses.get(summary.siteId) ?? null}
           defaultExpanded={expandFirst && index === 0}
         />
       ))}

--- a/components/burn/ProdStatusBadge.tsx
+++ b/components/burn/ProdStatusBadge.tsx
@@ -1,0 +1,16 @@
+import type { ProdStatus } from './useProdStatus';
+
+/**
+ * Production status badge: ✓ all lines running, ∅ stopped/idle, ? unknown.
+ * Distinct symbols (not colour alone) keep the states legible under CVD.
+ */
+export function ProdStatusBadge({ status }: { status: ProdStatus }) {
+  if (status === null) {
+    return <span className="px-2 py-0.5 text-xs font-medium bg-apxm-bg text-apxm-muted">?</span>;
+  }
+  return status ? (
+    <span className="px-2 py-0.5 text-xs font-medium bg-status-ok/20 text-status-ok">✓</span>
+  ) : (
+    <span className="px-2 py-0.5 text-xs font-medium bg-status-critical/20 text-status-critical">∅</span>
+  );
+}

--- a/components/burn/RepairAgeBadge.tsx
+++ b/components/burn/RepairAgeBadge.tsx
@@ -1,0 +1,27 @@
+import { useSettingsStore } from '../../stores/settings';
+import { classifyRepairUrgency, type RepairUrgency } from '../../core/repair';
+
+const urgencyColors: Record<RepairUrgency, string> = {
+  critical: 'bg-status-critical/20 text-status-critical',
+  warning: 'bg-status-warning/20 text-status-warning',
+  ok: 'bg-status-ok/20 text-status-ok',
+};
+
+/**
+ * Days-since-last-repair badge, coloured by the user's repair thresholds.
+ * Null age (no repairable buildings on the site) renders a muted dash.
+ */
+export function RepairAgeBadge({ ageDays }: { ageDays: number | null }) {
+  const thresholds = useSettingsStore((s) => s.repairThresholds);
+
+  if (ageDays === null) {
+    return <span className="text-xs text-apxm-muted">—</span>;
+  }
+
+  const urgency = classifyRepairUrgency(ageDays, thresholds);
+  return (
+    <span className={`px-2 py-0.5 text-xs font-medium ${urgencyColors[urgency]}`}>
+      {Math.floor(ageDays)}d
+    </span>
+  );
+}

--- a/components/burn/SiteBurnCard.tsx
+++ b/components/burn/SiteBurnCard.tsx
@@ -1,15 +1,26 @@
 import { useState } from 'react';
 import type { SiteBurnSummary, BurnRate } from '../../core/burn';
+import { classifyRepairUrgency } from '../../core/repair';
 import { useRefreshState } from '../../stores/refreshState';
+import { useSettingsStore } from '../../stores/settings';
 import { executeBufferRefresh, buildBufferCommand } from '../../lib/buffer-refresh';
 import { useSiteStaleness } from '../../hooks/useSiteStaleness';
-import { BurnBadge } from './BurnBadge';
 import { BurnRow } from './BurnRow';
+import { BaseStatusTile, type TileTone } from './BaseStatusTile';
+import type { ProdStatus } from './useProdStatus';
 
 interface SiteBurnCardProps {
   summary: SiteBurnSummary;
+  /** Days since last repair on the site's oldest production building (null = none) */
+  repairAgeDays: number | null;
+  /** Production status (null = unknown, true = all running, false = stopped/idle) */
+  prodStatus: ProdStatus;
   /** Start expanded */
   defaultExpanded?: boolean;
+}
+
+function formatDays(days: number): string {
+  return days < 1 ? '<1d' : `${Math.floor(days)}d`;
 }
 
 /**
@@ -47,18 +58,33 @@ function sortBurns(burns: BurnRate[]): BurnRate[] {
  * Card showing burn summary for a single site.
  * Collapsible with header showing site name and most urgent item.
  */
-export function SiteBurnCard({ summary, defaultExpanded = false }: SiteBurnCardProps) {
+export function SiteBurnCard({
+  summary,
+  repairAgeDays,
+  prodStatus,
+  defaultExpanded = false,
+}: SiteBurnCardProps) {
   const [expanded, setExpanded] = useState(defaultExpanded);
   const { siteId, siteName, burns, mostUrgent } = summary;
 
   const { text: stalenessText, colorClass: stalenessColor } = useSiteStaleness(siteId);
+  const repairThresholds = useSettingsStore((s) => s.repairThresholds);
 
   const mode = useRefreshState((s) => s.mode);
   const siteStatus = useRefreshState((s) => s.siteStatus.get(siteId));
 
   const sortedBurns = sortBurns(burns);
-  const criticalCount = burns.filter((b) => b.urgency === 'critical').length;
-  const warningCount = burns.filter((b) => b.urgency === 'warning').length;
+
+  // Tile tones: burn from mostUrgent urgency (surplus folds into ok),
+  // repair from the user's threshold/offset settings
+  const burnTone: TileTone = mostUrgent
+    ? mostUrgent.urgency === 'surplus'
+      ? 'ok'
+      : mostUrgent.urgency
+    : 'muted';
+  const repairTone: TileTone =
+    repairAgeDays === null ? 'muted' : classifyRepairUrgency(repairAgeDays, repairThresholds);
+  const prodTone: TileTone = prodStatus === null ? 'muted' : prodStatus ? 'ok' : 'critical';
 
   const showRefreshButton = mode === 'manual' || mode === 'batch';
   const isLoading = siteStatus === 'loading';
@@ -92,17 +118,6 @@ export function SiteBurnCard({ summary, defaultExpanded = false }: SiteBurnCardP
             )}
           </div>
 
-          {/* Quick counts */}
-          {criticalCount > 0 && (
-            <span className="text-xs px-1.5 py-0.5 bg-status-critical/20 text-status-critical">
-              {criticalCount}
-            </span>
-          )}
-          {warningCount > 0 && (
-            <span className="text-xs px-1.5 py-0.5 bg-status-warning/20 text-status-warning">
-              {warningCount}
-            </span>
-          )}
         </div>
 
         <div className="flex items-center gap-2">
@@ -136,13 +151,22 @@ export function SiteBurnCard({ summary, defaultExpanded = false }: SiteBurnCardP
             </span>
           )}
 
-          {/* Most urgent item preview */}
-          {mostUrgent && (
-            <>
-              <span className="text-xs text-apxm-text/70">{mostUrgent.materialTicker}</span>
-              <BurnBadge urgency={mostUrgent.urgency} daysRemaining={mostUrgent.daysRemaining} />
-            </>
-          )}
+          {/* BURN / REPAIR / PROD status tiles */}
+          <BaseStatusTile
+            label="Burn"
+            value={mostUrgent ? formatDays(mostUrgent.daysRemaining) : '—'}
+            tone={burnTone}
+          />
+          <BaseStatusTile
+            label="Repair"
+            value={repairAgeDays === null ? '—' : formatDays(repairAgeDays)}
+            tone={repairTone}
+          />
+          <BaseStatusTile
+            label="Prod"
+            value={prodStatus === null ? '?' : prodStatus ? '✓' : '∅'}
+            tone={prodTone}
+          />
         </div>
       </button>
 

--- a/components/burn/index.ts
+++ b/components/burn/index.ts
@@ -4,3 +4,8 @@ export { SiteBurnCard } from './SiteBurnCard';
 export { BurnSummaryList, BurnSummaryCompact } from './BurnSummaryList';
 export { useSiteBurns, sortByUrgency } from './useSiteBurns';
 export { DataSourceBadge } from './DataSourceBadge';
+export { useRepairStatus, type RepairStatusSummary } from './useRepairStatus';
+export { useProdStatuses, type ProdStatus } from './useProdStatus';
+export { RepairAgeBadge } from './RepairAgeBadge';
+export { ProdStatusBadge } from './ProdStatusBadge';
+export { BaseStatusTile, type TileTone } from './BaseStatusTile';

--- a/components/burn/useProdStatus.ts
+++ b/components/burn/useProdStatus.ts
@@ -1,0 +1,46 @@
+/**
+ * Adapted from jackinabox86's APXM fork (https://github.com/jackinabox86/APXM),
+ * MIT licensed — credit jackinabox86.
+ */
+import { useMemo } from 'react';
+import { useSitesStore } from '../../stores/entities/sites';
+import {
+  useProductionStore,
+  useProductionLoadedStore,
+  getProductionBySiteId,
+} from '../../stores/entities/production';
+
+/**
+ * Production status per site:
+ * null  = no data for this site yet → show ?
+ * true  = every production line has a running order → show ✓
+ * false = any line idle, or no lines at all → show ∅
+ */
+export type ProdStatus = boolean | null;
+
+export function useProdStatuses(): Map<string, ProdStatus> {
+  const sitesLastUpdated = useSitesStore((s) => s.lastUpdated);
+  const productionLastUpdated = useProductionStore((s) => s.lastUpdated);
+  const loadedSiteIds = useProductionLoadedStore((s) => s.loadedSiteIds);
+
+  return useMemo(() => {
+    const map = new Map<string, ProdStatus>();
+    for (const site of useSitesStore.getState().getAll()) {
+      const lines = getProductionBySiteId(site.siteId);
+      if (lines.length === 0 && !loadedSiteIds.has(site.siteId)) {
+        // Cache-rehydrated or FIO lines self-evidence as loaded by being
+        // present; only a site with no lines AND no load marker is unknown.
+        map.set(site.siteId, null);
+      } else {
+        map.set(
+          site.siteId,
+          lines.length > 0 &&
+            lines.every((line) => line.orders.some((o) => o.started !== null && !o.halted))
+        );
+      }
+    }
+    return map;
+    // lastUpdated values are the recompute triggers; data is read from stores
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sitesLastUpdated, productionLastUpdated, loadedSiteIds]);
+}

--- a/components/burn/useRepairStatus.ts
+++ b/components/burn/useRepairStatus.ts
@@ -1,0 +1,23 @@
+/**
+ * Adapted from jackinabox86's APXM fork (https://github.com/jackinabox86/APXM),
+ * MIT licensed — credit jackinabox86.
+ */
+import { useMemo } from 'react';
+import { useSitesStore } from '../../stores/entities/sites';
+import { calculateAllRepairStatuses, type RepairStatusSummary } from '../../core/repair';
+
+export type { RepairStatusSummary };
+
+/**
+ * Hook that calculates repair status for all sites.
+ * Re-calculates when site/platform data changes (platforms are part of site entities).
+ */
+export function useRepairStatus(): RepairStatusSummary[] {
+  const sitesLastUpdated = useSitesStore((s) => s.lastUpdated);
+
+  return useMemo(() => {
+    return calculateAllRepairStatuses();
+    // sitesLastUpdated is the recompute trigger; the data is read from the store
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sitesLastUpdated]);
+}

--- a/components/layout/TabBar.tsx
+++ b/components/layout/TabBar.tsx
@@ -8,7 +8,7 @@ interface TabConfig {
 
 const tabs: TabConfig[] = [
   { id: 'status', label: 'STATUS' },
-  { id: 'bases', label: 'BURN' },
+  { id: 'bases', label: 'BASE' },
   { id: 'fleet', label: 'FLEET' },
   { id: 'contracts', label: 'CONTRACTS' },
   { id: 'settings', label: 'SET' },

--- a/components/status/BasesMiniList.tsx
+++ b/components/status/BasesMiniList.tsx
@@ -1,5 +1,13 @@
 import { useMemo } from 'react';
-import { useSiteBurns, sortByUrgency, DataSourceBadge } from '../burn';
+import {
+  useSiteBurns,
+  sortByUrgency,
+  DataSourceBadge,
+  useRepairStatus,
+  useProdStatuses,
+  RepairAgeBadge,
+  ProdStatusBadge,
+} from '../burn';
 import { Card, SectionHeader, TimeBadge } from '../shared';
 import { useGameState } from '../../stores/gameState';
 import { useConnectionStore } from '../../stores/connection';
@@ -17,6 +25,13 @@ import { useStorageStore } from '../../stores/entities/storage';
 export function BasesMiniList() {
   const { setActiveTab } = useGameState();
   const siteBurns = useSiteBurns();
+  const repairStatuses = useRepairStatus();
+  const prodStatuses = useProdStatuses();
+
+  const repairBySite = useMemo(
+    () => new Map(repairStatuses.map((r) => [r.siteId, r])),
+    [repairStatuses]
+  );
 
   const apexUnresponsive = useConnectionStore((s) => s.apexUnresponsive);
   const sitesFetched = useSitesStore((s) => s.fetched);
@@ -34,9 +49,15 @@ export function BasesMiniList() {
   const lastUpdated = source === 'fio' ? fioLastFetch : oldestUpdate;
 
   const topBases = useMemo(() => {
-    const sorted = sortByUrgency(siteBurns);
+    // Stopped production bubbles above burn urgency — it's the loudest alarm
+    const sorted = [...sortByUrgency(siteBurns)].sort((a, b) => {
+      const aStopped = prodStatuses.get(a.siteId) === false;
+      const bStopped = prodStatuses.get(b.siteId) === false;
+      if (aStopped !== bStopped) return aStopped ? -1 : 1;
+      return 0; // stable: keep burn-urgency order within each group
+    });
     return sorted.slice(0, 5);
-  }, [siteBurns]);
+  }, [siteBurns, prodStatuses]);
 
   // Determine loading state for empty-state message
   const emptyMessage = apexUnresponsive && !sitesFetched
@@ -65,18 +86,32 @@ export function BasesMiniList() {
         onViewAll={() => setActiveTab('bases')}
         accessory={<DataSourceBadge source={source} lastUpdated={lastUpdated} />}
       />
-      <div className="space-y-0">
+      <div className="grid grid-cols-[minmax(0,1fr)_3.5rem_3.5rem_2.5rem] gap-x-2 items-center">
+        {/* Column headers */}
+        <span />
+        <span className="text-[10px] text-apxm-text/40 uppercase tracking-wide text-center">Burn</span>
+        <span className="text-[10px] text-apxm-text/40 uppercase tracking-wide text-center">Repair</span>
+        <span className="text-[10px] text-apxm-text/40 uppercase tracking-wide text-center">Prod</span>
+
         {topBases.map((site) => (
-          <div key={site.siteId} className="flex items-center justify-between py-1">
-            <span className="text-sm text-apxm-text truncate flex-1 mr-2">{site.siteName}</span>
-            {site.mostUrgent ? (
-              <TimeBadge
-                daysRemaining={site.mostUrgent.daysRemaining}
-                urgency={site.mostUrgent.urgency}
-              />
-            ) : (
-              <span className="text-xs text-apxm-muted">OK</span>
-            )}
+          <div key={site.siteId} className="contents">
+            <span className="text-sm text-apxm-text truncate py-1">{site.siteName}</span>
+            <span className="text-center">
+              {site.mostUrgent ? (
+                <TimeBadge
+                  daysRemaining={site.mostUrgent.daysRemaining}
+                  urgency={site.mostUrgent.urgency}
+                />
+              ) : (
+                <span className="text-xs text-apxm-muted">OK</span>
+              )}
+            </span>
+            <span className="text-center">
+              <RepairAgeBadge ageDays={repairBySite.get(site.siteId)?.oldestBuildingAgeDays ?? null} />
+            </span>
+            <span className="text-center">
+              <ProdStatusBadge status={prodStatuses.get(site.siteId) ?? null} />
+            </span>
           </div>
         ))}
       </div>

--- a/components/views/BasesView.tsx
+++ b/components/views/BasesView.tsx
@@ -1,5 +1,7 @@
+import { useMemo } from 'react';
 import { FilterBar, type FilterOption, DataGate, type RequiredStore } from '../shared';
 import { SiteBurnCard } from '../burn/SiteBurnCard';
+import { useRepairStatus, useProdStatuses } from '../burn';
 import { useFilteredBurns, type BurnFilter } from './hooks';
 import { useSitesStore } from '../../stores/entities/sites';
 import { useGameState } from '../../stores/gameState';
@@ -22,6 +24,12 @@ export function BasesView() {
   const activeFilters = useGameState((s) => s.burnFilters);
   const toggleBurnFilter = useGameState((s) => s.toggleBurnFilter);
   const { summaries, counts } = useFilteredBurns(activeFilters);
+  const repairStatuses = useRepairStatus();
+  const prodStatuses = useProdStatuses();
+  const repairBySite = useMemo(
+    () => new Map(repairStatuses.map((r) => [r.siteId, r])),
+    [repairStatuses]
+  );
 
   const sitesFetched = useSitesStore((s) => s.fetched);
 
@@ -55,6 +63,8 @@ export function BasesView() {
               <SiteBurnCard
                 key={summary.siteId}
                 summary={summary}
+                repairAgeDays={repairBySite.get(summary.siteId)?.oldestBuildingAgeDays ?? null}
+                prodStatus={prodStatuses.get(summary.siteId) ?? null}
                 defaultExpanded={false}
               />
             ))}

--- a/components/views/SettingsView.tsx
+++ b/components/views/SettingsView.tsx
@@ -1,6 +1,11 @@
 import { useState, useEffect } from 'react';
 import { Card, MaterialTile } from '../shared';
-import { useSettingsStore, DEFAULT_THRESHOLDS, type MaterialTheme } from '../../stores/settings';
+import {
+  useSettingsStore,
+  DEFAULT_THRESHOLDS,
+  DEFAULT_REPAIR_THRESHOLDS,
+  type MaterialTheme,
+} from '../../stores/settings';
 import { testConnection, populateStoresFromFio, type FioProgressStep } from '../../lib/fio';
 import { clearAllCache } from '../../stores/cache';
 import { themePresets } from '../../lib/theme';
@@ -40,6 +45,19 @@ export function validateThresholds(
   }
   if (resupply < warning) {
     return 'Resupply target must be at least the warning threshold';
+  }
+  return null;
+}
+
+export function validateRepairThresholds(
+  threshold: number,
+  offset: number
+): string | null {
+  if (threshold <= 0 || offset <= 0) {
+    return 'All values must be greater than 0';
+  }
+  if (offset >= threshold) {
+    return 'Offset must be less than the threshold';
   }
   return null;
 }
@@ -93,6 +111,46 @@ export function SettingsView() {
   const handleResetThresholds = () => {
     setBurnThresholds(DEFAULT_THRESHOLDS);
     setThresholdError(null);
+  };
+
+  // Repair threshold local state — same string-edit pattern as burn thresholds
+  const { repairThresholds, setRepairThresholds } = useSettingsStore();
+  const [repairThreshold, setRepairThreshold] = useState(String(repairThresholds.threshold));
+  const [repairOffset, setRepairOffset] = useState(String(repairThresholds.offset));
+  const [repairError, setRepairError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setRepairThreshold(String(repairThresholds.threshold));
+    setRepairOffset(String(repairThresholds.offset));
+  }, [repairThresholds.threshold, repairThresholds.offset]);
+
+  const handleRepairChange = (field: 'threshold' | 'offset', value: string) => {
+    if (field === 'threshold') setRepairThreshold(value);
+    if (field === 'offset') setRepairOffset(value);
+
+    const num = parseFloat(value);
+    if (isNaN(num) || value.trim() === '') {
+      setRepairError(null);
+      return;
+    }
+
+    const current = {
+      threshold: parseFloat(repairThreshold),
+      offset: parseFloat(repairOffset),
+      [field]: num,
+    };
+
+    const error = validateRepairThresholds(current.threshold, current.offset);
+    setRepairError(error);
+
+    if (!error) {
+      setRepairThresholds({ [field]: num });
+    }
+  };
+
+  const handleResetRepairThresholds = () => {
+    setRepairThresholds(DEFAULT_REPAIR_THRESHOLDS);
+    setRepairError(null);
   };
 
   const [username, setUsername] = useState('');
@@ -228,6 +286,51 @@ export function SettingsView() {
 
           <button
             onClick={handleResetThresholds}
+            className="w-full min-h-touch px-4 py-2 text-sm rounded border border-apxm-accent text-apxm-muted font-semibold hover:border-prun-yellow hover:text-prun-yellow"
+          >
+            Reset to Defaults
+          </button>
+        </div>
+      </Card>
+
+      {/* Repair Thresholds Section */}
+      <Card>
+        <h2 className="text-prun-yellow text-sm font-semibold mb-1">Repair Thresholds</h2>
+        <p className="text-xs text-apxm-muted mb-3">
+          Days since last repair on a base's production buildings
+        </p>
+
+        <div className="space-y-3">
+          <div className="flex gap-3">
+            <div className="flex-1">
+              <label className="block text-apxm-muted text-xs mb-1">Threshold (red)</label>
+              <input
+                type="number"
+                value={repairThreshold}
+                onChange={(e) => handleRepairChange('threshold', e.target.value)}
+                className="w-full min-h-touch px-3 py-2 text-sm bg-apxm-bg border border-apxm-accent rounded text-apxm-text outline-none focus:border-prun-yellow"
+              />
+            </div>
+
+            <div className="flex-1">
+              <label className="block text-apxm-muted text-xs mb-1">Offset (yellow)</label>
+              <input
+                type="number"
+                value={repairOffset}
+                onChange={(e) => handleRepairChange('offset', e.target.value)}
+                className="w-full min-h-touch px-3 py-2 text-sm bg-apxm-bg border border-apxm-accent rounded text-apxm-text outline-none focus:border-prun-yellow"
+              />
+            </div>
+          </div>
+
+          <p className="text-xs text-apxm-muted">
+            Offset: turns yellow this many days before the threshold (e.g. 60/10 → yellow at 50d, red at 60d)
+          </p>
+
+          {repairError && <p className="text-xs text-status-critical">{repairError}</p>}
+
+          <button
+            onClick={handleResetRepairThresholds}
             className="w-full min-h-touch px-4 py-2 text-sm rounded border border-apxm-accent text-apxm-muted font-semibold hover:border-prun-yellow hover:text-prun-yellow"
           >
             Reset to Defaults

--- a/components/views/__tests__/SettingsView.test.ts
+++ b/components/views/__tests__/SettingsView.test.ts
@@ -1,6 +1,46 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { validateThresholds } from '../SettingsView';
-import { useSettingsStore, DEFAULT_THRESHOLDS } from '../../../stores/settings';
+import { validateThresholds, validateRepairThresholds } from '../SettingsView';
+import {
+  useSettingsStore,
+  DEFAULT_THRESHOLDS,
+  DEFAULT_REPAIR_THRESHOLDS,
+} from '../../../stores/settings';
+
+describe('SettingsView repair threshold validation', () => {
+  describe('validateRepairThresholds', () => {
+    it('returns null for valid values', () => {
+      expect(validateRepairThresholds(60, 10)).toBeNull();
+    });
+
+    it('rejects offset >= threshold', () => {
+      expect(validateRepairThresholds(60, 60)).toBe('Offset must be less than the threshold');
+      expect(validateRepairThresholds(60, 70)).toBe('Offset must be less than the threshold');
+    });
+
+    it('rejects zero and negative values', () => {
+      expect(validateRepairThresholds(0, 10)).toBe('All values must be greater than 0');
+      expect(validateRepairThresholds(60, 0)).toBe('All values must be greater than 0');
+      expect(validateRepairThresholds(-60, -10)).toBe('All values must be greater than 0');
+    });
+  });
+
+  describe('store integration', () => {
+    beforeEach(() => {
+      useSettingsStore.getState().reset();
+    });
+
+    it('defaults match DEFAULT_REPAIR_THRESHOLDS (60/10)', () => {
+      expect(useSettingsStore.getState().repairThresholds).toEqual(DEFAULT_REPAIR_THRESHOLDS);
+    });
+
+    it('setRepairThresholds persists partial updates', () => {
+      useSettingsStore.getState().setRepairThresholds({ offset: 14 });
+      const { repairThresholds } = useSettingsStore.getState();
+      expect(repairThresholds.offset).toBe(14);
+      expect(repairThresholds.threshold).toBe(60);
+    });
+  });
+});
 
 describe('SettingsView burn threshold validation', () => {
   describe('validateThresholds', () => {

--- a/core/__tests__/repair.test.ts
+++ b/core/__tests__/repair.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  isRepairableBuilding,
+  getBuildingLastRepairTimestamp,
+  classifyRepairUrgency,
+  calculateSiteRepairStatus,
+} from '../repair';
+import { useSitesStore } from '../../stores/entities/sites';
+import {
+  createTestSite,
+  createPlatform,
+  createPlatformModule,
+} from '../../__tests__/fixtures/factories';
+import type { PrunApi } from '../../types/prun-api';
+
+const MS_PER_DAY = 86400000;
+const THRESHOLDS = { threshold: 60, offset: 10 };
+
+function platformOfType(
+  type: PrunApi.PlatformModuleType,
+  overrides: Partial<PrunApi.Platform> = {}
+): PrunApi.Platform {
+  return createPlatform({ module: createPlatformModule({ type }), ...overrides });
+}
+
+describe('isRepairableBuilding', () => {
+  it('includes PRODUCTION and RESOURCES — both degrade and need repair', () => {
+    expect(isRepairableBuilding(platformOfType('PRODUCTION'))).toBe(true);
+    expect(isRepairableBuilding(platformOfType('RESOURCES'))).toBe(true);
+  });
+
+  it('excludes CORE, HABITATION, and STORAGE', () => {
+    expect(isRepairableBuilding(platformOfType('CORE'))).toBe(false);
+    expect(isRepairableBuilding(platformOfType('HABITATION'))).toBe(false);
+    expect(isRepairableBuilding(platformOfType('STORAGE'))).toBe(false);
+  });
+});
+
+describe('getBuildingLastRepairTimestamp', () => {
+  it('uses lastRepair when present', () => {
+    const p = createPlatform({ lastRepair: { timestamp: 1000 } });
+    expect(getBuildingLastRepairTimestamp(p)).toBe(1000);
+  });
+
+  it('falls back to creationTime for never-repaired buildings', () => {
+    const p = createPlatform({ lastRepair: null, creationTime: { timestamp: 2000 } });
+    expect(getBuildingLastRepairTimestamp(p)).toBe(2000);
+  });
+});
+
+describe('classifyRepairUrgency', () => {
+  it('is critical at and beyond the threshold', () => {
+    expect(classifyRepairUrgency(60, THRESHOLDS)).toBe('critical');
+    expect(classifyRepairUrgency(90, THRESHOLDS)).toBe('critical');
+  });
+
+  it('is warning within offset days of the threshold', () => {
+    expect(classifyRepairUrgency(50, THRESHOLDS)).toBe('warning');
+    expect(classifyRepairUrgency(59.9, THRESHOLDS)).toBe('warning');
+  });
+
+  it('is ok below the warning window', () => {
+    expect(classifyRepairUrgency(49.9, THRESHOLDS)).toBe('ok');
+    expect(classifyRepairUrgency(0, THRESHOLDS)).toBe('ok');
+  });
+});
+
+describe('calculateSiteRepairStatus', () => {
+  beforeEach(() => {
+    useSitesStore.getState().clear();
+  });
+
+  it('returns nulls when the site has no repairable buildings', () => {
+    const site = createTestSite({
+      siteId: 'site-hab-only',
+      platforms: [
+        platformOfType('HABITATION', { siteId: 'site-hab-only' }),
+        platformOfType('CORE', { siteId: 'site-hab-only' }),
+      ],
+    });
+    useSitesStore.getState().setAll([site]);
+
+    const result = calculateSiteRepairStatus('site-hab-only');
+    expect(result.oldestBuildingAgeDays).toBeNull();
+    expect(result.oldestBuildingCondition).toBeNull();
+  });
+
+  it('reports the oldest repairable building age and its condition', () => {
+    const now = Date.now();
+    const site = createTestSite({
+      siteId: 'site-1',
+      platforms: [
+        // repaired 10 days ago
+        platformOfType('PRODUCTION', {
+          siteId: 'site-1',
+          lastRepair: { timestamp: now - 10 * MS_PER_DAY },
+          condition: 0.95,
+        }),
+        // never repaired, built 40 days ago — this is the oldest
+        platformOfType('RESOURCES', {
+          siteId: 'site-1',
+          lastRepair: null,
+          creationTime: { timestamp: now - 40 * MS_PER_DAY },
+          condition: 0.8,
+        }),
+        // habitation older than both, but not repairable — must be ignored
+        platformOfType('HABITATION', {
+          siteId: 'site-1',
+          lastRepair: null,
+          creationTime: { timestamp: now - 200 * MS_PER_DAY },
+          condition: 0.5,
+        }),
+      ],
+    });
+    useSitesStore.getState().setAll([site]);
+
+    const result = calculateSiteRepairStatus('site-1');
+    expect(result.oldestBuildingAgeDays).toBeCloseTo(40, 0);
+    expect(result.oldestBuildingCondition).toBe(0.8);
+  });
+
+  it('returns nulls for an unknown site', () => {
+    const result = calculateSiteRepairStatus('nope');
+    expect(result.oldestBuildingAgeDays).toBeNull();
+    expect(result.oldestBuildingCondition).toBeNull();
+  });
+});

--- a/core/repair.ts
+++ b/core/repair.ts
@@ -1,0 +1,108 @@
+/**
+ * Repair Status Calculation Engine
+ *
+ * Computes the age and condition of the oldest repairable building per site.
+ * Urgency classification is settings-driven (threshold/offset), mirroring the
+ * burn thresholds pattern.
+ *
+ * Adapted from jackinabox86's APXM fork (https://github.com/jackinabox86/APXM),
+ * MIT licensed — credit jackinabox86. Changes: urgency classification reads
+ * user-configurable thresholds instead of hardcoded 60/50 days.
+ */
+
+import type { PrunApi } from '../types/prun-api';
+import { useSitesStore } from '../stores/entities/sites';
+import type { RepairThresholds } from '../stores/settings';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface RepairStatusSummary {
+  siteId: string;
+  /** Days since the oldest building was last repaired (or built). Null if no repairable buildings. */
+  oldestBuildingAgeDays: number | null;
+  /** Condition (0–1) of the oldest building. Null if no repairable buildings. */
+  oldestBuildingCondition: number | null;
+}
+
+export type RepairUrgency = 'critical' | 'warning' | 'ok';
+
+// ============================================================================
+// Helper Functions (exported for testing)
+// ============================================================================
+
+const MS_PER_DAY = 86400000;
+
+/**
+ * Returns true for building types that are eligible for repair.
+ * Only PRODUCTION and RESOURCES buildings degrade in a way that needs
+ * repairing — CORE, HABITATION, and STORAGE are excluded (domain rule,
+ * confirmed 2026-06-10, #24).
+ */
+export function isRepairableBuilding(platform: PrunApi.Platform): boolean {
+  return platform.module.type === 'RESOURCES' || platform.module.type === 'PRODUCTION';
+}
+
+/**
+ * Returns the timestamp (ms) of the last repair, or creation time if never repaired.
+ */
+export function getBuildingLastRepairTimestamp(platform: PrunApi.Platform): number {
+  return platform.lastRepair?.timestamp ?? platform.creationTime.timestamp;
+}
+
+/**
+ * Classifies a repair age against the user's thresholds:
+ * red at >= threshold days, yellow within `offset` days of it.
+ */
+export function classifyRepairUrgency(
+  ageDays: number,
+  thresholds: RepairThresholds
+): RepairUrgency {
+  if (ageDays >= thresholds.threshold) return 'critical';
+  if (ageDays >= thresholds.threshold - thresholds.offset) return 'warning';
+  return 'ok';
+}
+
+// ============================================================================
+// Main Entry Points
+// ============================================================================
+
+/**
+ * Calculates repair status for a single site.
+ * "Oldest" means the building with the earliest last-repair (or creation)
+ * timestamp, i.e. the one that has gone the longest without repair.
+ */
+export function calculateSiteRepairStatus(siteId: string): RepairStatusSummary {
+  const site = useSitesStore.getState().getById(siteId);
+  const repairable = (site?.platforms ?? []).filter(isRepairableBuilding);
+
+  if (repairable.length === 0) {
+    return { siteId, oldestBuildingAgeDays: null, oldestBuildingCondition: null };
+  }
+
+  let oldestPlatform = repairable[0];
+  let oldestTimestamp = getBuildingLastRepairTimestamp(repairable[0]);
+
+  for (let i = 1; i < repairable.length; i++) {
+    const ts = getBuildingLastRepairTimestamp(repairable[i]);
+    if (ts < oldestTimestamp) {
+      oldestTimestamp = ts;
+      oldestPlatform = repairable[i];
+    }
+  }
+
+  return {
+    siteId,
+    oldestBuildingAgeDays: (Date.now() - oldestTimestamp) / MS_PER_DAY,
+    oldestBuildingCondition: oldestPlatform.condition,
+  };
+}
+
+/**
+ * Calculates repair status for all sites.
+ */
+export function calculateAllRepairStatuses(): RepairStatusSummary[] {
+  const sites = useSitesStore.getState().getAll();
+  return sites.map((site) => calculateSiteRepairStatus(site.siteId));
+}

--- a/stores/__tests__/message-handlers.test.ts
+++ b/stores/__tests__/message-handlers.test.ts
@@ -10,6 +10,7 @@ import {
   useShipsStore,
   useFlightsStore,
   useContractsStore,
+  useProductionLoadedStore,
   clearAllEntityStores,
 } from '../entities';
 import {
@@ -41,6 +42,7 @@ describe('message-handlers', () => {
     clearAllEntityStores();
     useSiteSourceStore.getState().clear();
     useCompanyStore.getState().clear();
+    useProductionLoadedStore.getState().clear();
     useConnectionStore.setState({
       connected: false,
       lastMessageTimestamp: null,
@@ -283,6 +285,38 @@ describe('message-handlers', () => {
 
       expect(useWorkforceStore.getState().entities.size).toBe(1);
       expect(useWorkforceStore.getState().getById('site-1')).toBeDefined();
+    });
+  });
+
+  describe('production loaded tracking', () => {
+    it('marks sites loaded on per-site production data', () => {
+      dispatchMessage('PRODUCTION_SITE_PRODUCTION_LINES', {
+        productionLines: [createTestProductionLine({ siteId: 'site-A' })],
+      });
+
+      expect(useProductionLoadedStore.getState().loadedSiteIds.has('site-A')).toBe(true);
+      expect(useProductionLoadedStore.getState().loadedSiteIds.has('site-B')).toBe(false);
+    });
+
+    it('marks sites loaded on bulk production data', () => {
+      dispatchMessage('PRODUCTION_PRODUCTION_LINES', {
+        productionLines: [
+          createTestProductionLine({ siteId: 'site-A' }),
+          createTestProductionLine({ siteId: 'site-B' }),
+        ],
+      });
+
+      expect(useProductionLoadedStore.getState().loadedSiteIds.has('site-A')).toBe(true);
+      expect(useProductionLoadedStore.getState().loadedSiteIds.has('site-B')).toBe(true);
+    });
+
+    it('clears loaded markers on reconnection', () => {
+      dispatchMessage('CLIENT_CONNECTION_OPENED', {});
+      useProductionLoadedStore.getState().markSitesLoaded(['site-A']);
+
+      dispatchMessage('CLIENT_CONNECTION_OPENED', {});
+
+      expect(useProductionLoadedStore.getState().loadedSiteIds.size).toBe(0);
     });
   });
 

--- a/stores/entities/index.ts
+++ b/stores/entities/index.ts
@@ -26,6 +26,7 @@ export {
 
 export {
   useProductionStore,
+  useProductionLoadedStore,
   getProductionBySiteId,
   type ProductionStore,
 } from './production';

--- a/stores/entities/production.ts
+++ b/stores/entities/production.ts
@@ -1,3 +1,4 @@
+import { create } from 'zustand';
 import { createEntityStore, type EntityStore } from '../create-entity-store';
 import type { PrunApi } from '../../types/prun-api';
 
@@ -8,6 +9,31 @@ export const useProductionStore = createEntityStore<PrunApi.ProductionLine>(
   (line) => line.id,
   { key: 'apxm_cache_production' }
 );
+
+/**
+ * Tracks which sites have received production data this session.
+ * Production arrives per-site, so "no lines in the store" is ambiguous:
+ * either the site genuinely has no production lines, or its data simply
+ * hasn't arrived yet. This set disambiguates so the UI can show an honest
+ * "unknown" instead of a false "stopped". Session-scoped — cleared on
+ * reconnect; cache-rehydrated lines self-evidence as loaded via their presence.
+ */
+interface ProductionLoadedState {
+  loadedSiteIds: ReadonlySet<string>;
+  markSitesLoaded: (siteIds: Iterable<string>) => void;
+  clear: () => void;
+}
+
+export const useProductionLoadedStore = create<ProductionLoadedState>((set) => ({
+  loadedSiteIds: new Set<string>(),
+  markSitesLoaded: (siteIds) =>
+    set((state) => {
+      const next = new Set(state.loadedSiteIds);
+      for (const id of siteIds) next.add(id);
+      return { loadedSiteIds: next };
+    }),
+  clear: () => set({ loadedSiteIds: new Set<string>() }),
+}));
 
 /**
  * Get all production lines for a specific site.

--- a/stores/message-handlers.ts
+++ b/stores/message-handlers.ts
@@ -11,6 +11,7 @@ import {
   useFlightsStore,
   useContractsStore,
   useBalancesStore,
+  useProductionLoadedStore,
   clearAllEntityStores,
   type WorkforceEntity,
 } from './entities';
@@ -98,9 +99,11 @@ export function initMessageHandlers(): void {
     if (reconnectCount > 0) {
       clearAllEntityStores();
       useSiteSourceStore.getState().clear();
-      // Not an entity store, so clearAllEntityStores doesn't cover it.
-      // COMPANY_DATA re-arrives with the login dump.
+      // Not entity stores, so clearAllEntityStores doesn't cover them.
+      // COMPANY_DATA re-arrives with the login dump; production loaded
+      // markers re-accumulate as per-site data arrives.
       useCompanyStore.getState().clear();
+      useProductionLoadedStore.getState().clear();
     }
     useConnectionStore.getState().incrementReconnectCount();
     useConnectionStore.getState().setConnected(true);
@@ -227,6 +230,9 @@ export function initMessageHandlers(): void {
     if (Array.isArray(payload?.productionLines)) {
       useProductionStore.getState().setAll(payload.productionLines);
       useProductionStore.getState().setFetched('websocket');
+      useProductionLoadedStore.getState().markSitesLoaded(
+        payload.productionLines.map((l) => l.siteId).filter(Boolean)
+      );
     } else {
       warn('PRODUCTION_PRODUCTION_LINES: unexpected payload structure', payload);
     }
@@ -250,6 +256,7 @@ export function initMessageHandlers(): void {
       }
       useProductionStore.getState().setMany(payload.productionLines);
       useProductionStore.getState().setFetched('websocket');
+      useProductionLoadedStore.getState().markSitesLoaded(siteIds);
     } else {
       warn('PRODUCTION_SITE_PRODUCTION_LINES: unexpected payload structure', payload);
     }

--- a/stores/settings.ts
+++ b/stores/settings.ts
@@ -9,6 +9,13 @@ export interface BurnThresholds {
   resupply: number; // days — default 30 (how much to buy)
 }
 
+// rPrun-style XIT REP model: one number per base (days since last repair on
+// its production buildings); red at threshold, yellow `offset` days before it.
+export interface RepairThresholds {
+  threshold: number; // days since last repair → red. default 60
+  offset: number; // days before threshold → yellow. default 10
+}
+
 export interface FioConfig {
   apiKey: string | null;
   username: string | null;
@@ -19,6 +26,7 @@ export type MaterialTheme = 'rprun' | 'prun';
 
 interface SettingsState {
   burnThresholds: BurnThresholds;
+  repairThresholds: RepairThresholds;
   fio: FioConfig;
   materialTheme: MaterialTheme;
   uiTheme: ApxmThemeId;
@@ -27,6 +35,7 @@ interface SettingsState {
 
 interface SettingsActions {
   setBurnThresholds: (thresholds: Partial<BurnThresholds>) => void;
+  setRepairThresholds: (thresholds: Partial<RepairThresholds>) => void;
   setFioConfig: (config: Partial<FioConfig>) => void;
   setFioLastFetch: (timestamp: number) => void;
   setMaterialTheme: (theme: MaterialTheme) => void;
@@ -39,6 +48,9 @@ type SettingsStore = SettingsState & SettingsActions;
 
 export const DEFAULT_THRESHOLDS: BurnThresholds = { critical: 3, warning: 5, resupply: 30 };
 
+// 60/10 matches the values proven on jackinabox86's fork (red 60d, yellow 50d)
+export const DEFAULT_REPAIR_THRESHOLDS: RepairThresholds = { threshold: 60, offset: 10 };
+
 const DEFAULT_FIO_CONFIG: FioConfig = {
   apiKey: null,
   username: null,
@@ -47,6 +59,7 @@ const DEFAULT_FIO_CONFIG: FioConfig = {
 
 const initialState: SettingsState = {
   burnThresholds: DEFAULT_THRESHOLDS,
+  repairThresholds: DEFAULT_REPAIR_THRESHOLDS,
   fio: DEFAULT_FIO_CONFIG,
   materialTheme: 'rprun',
   uiTheme: DEFAULT_THEME_ID,
@@ -124,6 +137,11 @@ export const useSettingsStore = create<SettingsStore>()(
           burnThresholds: { ...state.burnThresholds, ...thresholds },
         })),
 
+      setRepairThresholds: (thresholds) =>
+        set((state) => ({
+          repairThresholds: { ...state.repairThresholds, ...thresholds },
+        })),
+
       setFioConfig: (config) =>
         set((state) => ({
           fio: { ...state.fio, ...config },
@@ -153,6 +171,7 @@ export const useSettingsStore = create<SettingsStore>()(
           ...current,
           ...state,
           burnThresholds: { ...current.burnThresholds, ...state?.burnThresholds },
+          repairThresholds: { ...current.repairThresholds, ...state?.repairThresholds },
           fio: { ...current.fio, ...state?.fio },
         };
       },


### PR DESCRIPTION
The main body of #24 — per-base burn/repair/prod status, glanceable on the dashboard and the (renamed) BASE tab. First pass following jackinabox86's layout; refinement expected after live use.

## What

**Repair status** (`core/repair.ts`, adapted from [jackinabox86's fork](https://github.com/jackinabox86/APXM), MIT, credited):
- Per-base number = days since last repair (or build) of the **oldest PRODUCTION/RESOURCES building**. CORE/HABITATION/STORAGE excluded — they don't need repair (domain rule, confirmed in this issue).
- Colouring is settings-driven, rPrun-XIT-REP-style: **threshold** (red) + **offset** (yellow that many days before it), defaulting to 60/10 — the values proven on his fork. New Repair Thresholds section in Settings with validation.

**Production status** (semantics from his fork):
- ✓ every line has a running order · ∅ any line idle or no lines · **? data not loaded for that site yet** — backed by new per-site loaded-tracking, since production arrives per-site and an empty store is ambiguous. Distinct symbols, not colour alone (CVD rule).

**UI:**
- Dashboard bases mini-list → three-column BURN/REPAIR/PROD table; stopped production bubbles above burn urgency in the sort.
- Base cards swap the most-urgent-material preview for three labelled status tiles (the quick critical/warning count chips also retired — the BURN tile carries that signal).
- RES/REP action buttons from his layout are **not** included — they're act-engine territory (#25).
- Tab renamed **BURN → BASE**.

## Verification

- `npx tsc --noEmit` clean; 347 tests passing (+18: repair engine incl. domain-rule cases, threshold validation, loaded-tracking)
- Chrome + Firefox builds succeed
- **Pending live check:** `lastRepair` arriving on the WS dump is rprun-types-confidence, not yet live-verified — compare one base's REPAIR number against a repair you remember making.

🤖 Generated with [Claude Code](https://claude.com/claude-code)