### PR TITLE
feat(filters): BASE tab tiers match any indicator (#37)

### DIFF
--- a/components/views/BasesView.tsx
+++ b/components/views/BasesView.tsx
@@ -23,13 +23,15 @@ export function BasesView() {
   // the toggle rules (ALL reset, empty→ALL, full-set→ALL) live with it.
   const activeFilters = useGameState((s) => s.burnFilters);
   const toggleBurnFilter = useGameState((s) => s.toggleBurnFilter);
-  const { summaries, counts } = useFilteredBurns(activeFilters);
   const repairStatuses = useRepairStatus();
   const prodStatuses = useProdStatuses();
   const repairBySite = useMemo(
     () => new Map(repairStatuses.map((r) => [r.siteId, r])),
     [repairStatuses]
   );
+  // Filter tiers are worst-of-three (burn/repair/prod, #37), so the maps
+  // feeding the card indicators also feed the filter classification.
+  const { summaries, counts } = useFilteredBurns(activeFilters, repairBySite, prodStatuses);
 
   const sitesFetched = useSitesStore((s) => s.fetched);
 

--- a/components/views/hooks/__tests__/useFilteredBurns.test.ts
+++ b/components/views/hooks/__tests__/useFilteredBurns.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { getFilterForUrgency } from '../useFilteredBurns';
+import { getFilterForUrgency, getSiteIndicatorTier } from '../useFilteredBurns';
+import type { ProdStatus } from '../../../../core/prod';
 
 describe('getFilterForUrgency', () => {
   it('maps red/yellow/green urgencies to their own filter', () => {
@@ -14,5 +15,43 @@ describe('getFilterForUrgency', () => {
 
   it("maps missing burn data to 'ok'", () => {
     expect(getFilterForUrgency(undefined)).toBe('ok');
+  });
+});
+
+describe('getSiteIndicatorTier (#37 — worst of burn/repair/prod)', () => {
+  const THRESHOLDS = { threshold: 60, offset: 10 };
+  const prodFull: ProdStatus = { tier: 'full', active: 4, capacity: 4 };
+  const prodPartial: ProdStatus = { tier: 'partial', active: 2, capacity: 4 };
+  const prodStopped: ProdStatus = { tier: 'stopped', active: 0, capacity: 4 };
+
+  it('is ok when every indicator is healthy', () => {
+    expect(getSiteIndicatorTier('ok', 10, prodFull, THRESHOLDS)).toBe('ok');
+  });
+
+  it('burn urgency alone sets the tier', () => {
+    expect(getSiteIndicatorTier('critical', 10, prodFull, THRESHOLDS)).toBe('critical');
+    expect(getSiteIndicatorTier('warning', 10, prodFull, THRESHOLDS)).toBe('warning');
+  });
+
+  it('repair age alone elevates an otherwise-green site', () => {
+    expect(getSiteIndicatorTier('ok', 75, prodFull, THRESHOLDS)).toBe('critical');
+    expect(getSiteIndicatorTier('ok', 55, prodFull, THRESHOLDS)).toBe('warning');
+  });
+
+  it('production status alone elevates an otherwise-green site', () => {
+    expect(getSiteIndicatorTier('ok', 10, prodStopped, THRESHOLDS)).toBe('critical');
+    expect(getSiteIndicatorTier('ok', 10, prodPartial, THRESHOLDS)).toBe('warning');
+  });
+
+  it('the worst indicator wins across mixed states', () => {
+    expect(getSiteIndicatorTier('warning', 55, prodStopped, THRESHOLDS)).toBe('critical');
+    expect(getSiteIndicatorTier('ok', 75, prodPartial, THRESHOLDS)).toBe('critical');
+  });
+
+  it('unknown indicators never worsen a site — tier comes from what is known', () => {
+    // prod ? (null) and no repairable buildings (null) contribute nothing
+    expect(getSiteIndicatorTier('ok', null, null, THRESHOLDS)).toBe('ok');
+    expect(getSiteIndicatorTier('critical', null, null, THRESHOLDS)).toBe('critical');
+    expect(getSiteIndicatorTier('ok', 75, null, THRESHOLDS)).toBe('critical');
   });
 });

--- a/components/views/hooks/useFilteredBurns.ts
+++ b/components/views/hooks/useFilteredBurns.ts
@@ -1,9 +1,17 @@
 import { useMemo } from 'react';
 import { useSiteBurns, sortByUrgency } from '../../burn/useSiteBurns';
 import type { SiteBurnSummary, Urgency } from '../../../core/burn';
+import { classifyRepairUrgency } from '../../../core/repair';
+import { classifyProdUrgency, type ProdStatus } from '../../../core/prod';
+import type { RepairStatusSummary } from '../../burn/useRepairStatus';
+import { useSettingsStore } from '../../../stores/settings';
+import type { RepairThresholds } from '../../../stores/settings';
 import type { BurnFilter } from '../../../stores/gameState';
 
 export type { BurnFilter };
+
+/** A site's filter tier — BurnFilter minus the 'all' pseudo-filter. */
+export type SiteTier = Exclude<BurnFilter, 'all'>;
 
 export interface FilteredBurnsResult {
   summaries: SiteBurnSummary[];
@@ -16,21 +24,54 @@ export interface FilteredBurnsResult {
  * (workforce consumables always burn), so it gets no tier of its own.
  * Sites with no burn data also land in 'ok'.
  */
-export function getFilterForUrgency(urgency: Urgency | undefined): BurnFilter {
+export function getFilterForUrgency(urgency: Urgency | undefined): SiteTier {
   if (!urgency || urgency === 'surplus') return 'ok';
   return urgency;
 }
 
+const tierRank: Record<SiteTier, number> = { ok: 0, warning: 1, critical: 2 };
+
 /**
- * Hook that filters burn summaries by urgency level.
- * Returns filtered summaries and counts per filter category.
+ * Worst-of-three tier for a site (#37): RED/YELLOW match any indicator —
+ * burn urgency, repair age, or production status — so the filter answers
+ * "which bases need attention for any reason", not just burn. GREEN means
+ * every known indicator is ok. Unknown indicators (prod ?, no repairable
+ * buildings) don't contribute: they never worsen a site, so its tier comes
+ * from whatever is known.
  */
-export function useFilteredBurns(activeFilters: ReadonlySet<BurnFilter>): FilteredBurnsResult {
+export function getSiteIndicatorTier(
+  burnUrgency: Urgency | undefined,
+  repairAgeDays: number | null,
+  prodStatus: ProdStatus,
+  repairThresholds: RepairThresholds
+): SiteTier {
+  let worst: SiteTier = getFilterForUrgency(burnUrgency);
+  if (repairAgeDays !== null) {
+    const repair = classifyRepairUrgency(repairAgeDays, repairThresholds);
+    if (tierRank[repair] > tierRank[worst]) worst = repair;
+  }
+  if (prodStatus !== null) {
+    const prod = classifyProdUrgency(prodStatus.tier);
+    if (tierRank[prod] > tierRank[worst]) worst = prod;
+  }
+  return worst;
+}
+
+/**
+ * Hook that filters burn summaries by indicator tier (worst of burn,
+ * repair, prod). Returns filtered summaries and counts per filter category;
+ * a site counts once, under its worst tier.
+ */
+export function useFilteredBurns(
+  activeFilters: ReadonlySet<BurnFilter>,
+  repairBySite: ReadonlyMap<string, RepairStatusSummary>,
+  prodStatuses: ReadonlyMap<string, ProdStatus>
+): FilteredBurnsResult {
   const allBurns = useSiteBurns();
+  const repairThresholds = useSettingsStore((s) => s.repairThresholds);
   const sorted = sortByUrgency(allBurns);
 
   return useMemo(() => {
-    // Count sites per filter category
     const counts: Record<BurnFilter, number> = {
       all: sorted.length,
       critical: 0,
@@ -38,18 +79,23 @@ export function useFilteredBurns(activeFilters: ReadonlySet<BurnFilter>): Filter
       ok: 0,
     };
 
+    const tierBySite = new Map<string, SiteTier>();
     for (const summary of sorted) {
-      const category = getFilterForUrgency(summary.mostUrgent?.urgency);
-      counts[category]++;
+      const tier = getSiteIndicatorTier(
+        summary.mostUrgent?.urgency,
+        repairBySite.get(summary.siteId)?.oldestBuildingAgeDays ?? null,
+        prodStatuses.get(summary.siteId) ?? null,
+        repairThresholds
+      );
+      tierBySite.set(summary.siteId, tier);
+      counts[tier]++;
     }
 
     // Show all when 'all' is selected
     const summaries = activeFilters.has('all')
       ? sorted
-      : sorted.filter(
-          (s) => activeFilters.has(getFilterForUrgency(s.mostUrgent?.urgency))
-        );
+      : sorted.filter((s) => activeFilters.has(tierBySite.get(s.siteId) ?? 'ok'));
 
     return { summaries, counts };
-  }, [sorted, activeFilters]);
+  }, [sorted, activeFilters, repairBySite, prodStatuses, repairThresholds]);
 }


### PR DESCRIPTION
Closes #37. **Stacked on #39** — merge that first; GitHub will retarget this PR to main when the base branch is deleted.

The BASE tab RED/YELLOW/GREEN filters now classify each base by the **worst of its three indicators** — burn urgency, repair age (user thresholds), production status (full/partial/stopped from #39) — so the filter answers "which bases need attention for any reason", not just "which bases have a burn problem".

- A base counts once in the filter bar, under its worst tier
- Unknown indicators (prod `?`, no repairable buildings) contribute nothing — they never worsen a site; its tier comes from whatever is known (per the issue note)
- GREEN = every known indicator ok

**Tests:** 6 new for the worst-of classification (363 total). Both build targets verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)