### PR TITLE
docs(readme): mobile-only rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,24 +4,26 @@ A browser extension for [Prosperous Universe](https://prosperousuniverse.com) th
 
 Part of the [27Bit Industries](https://27bit.dev) tool suite for Prosperous Universe.
 
-## Mobile View
-
-### Features
+## Features
 
 Overlays the APEX mobile interface with a touch-focused UI while the underlying game client keeps running.
 
-- **Status Dashboard** — at-a-glance summaries of bases, fleet and contracts. Drill-down to full views.
+- **Status dashboard** — at-a-glance summaries of bases, fleet, contracts, and cash. Drill down to full views.
+- **Base status** — BURN / REPAIR / PROD indicators per base: days of supplies remaining, days since last repair, and production utilisation. RED/YELLOW/GREEN filters match any indicator, so the BASE tab answers "which bases need attention for any reason".
 - **Burn tracking** — per-site material burn rates with urgency indicators (critical/warning/ok). Purchase need calculation with resupply targets. Configurable thresholds.
-- **Fleet overview** — ship status, destinations, ETA countdowns.
+- **Fleet overview** — ship status, destinations, ETA countdowns, cargo and fuel.
 - **Contract monitoring** — active contracts with condition status and deadlines.
+- **Company & liquidity** — company identity and cash balances, primary currency first.
+- **Staleness indicators** — data surfaces show their source (live WebSocket / FIO / cache) and age. Burn numbers from stale data are worse than no numbers; APXM never hides how fresh its data is.
+- **UI themes** — five presets shared with Helm (PrUn, DryDock, CRT, Vivid, Colorblind), including a CVD-safe burn status palette.
 - **FIO integration** — auto-fetches data from the FIO REST API on startup if credentials are configured.
 - **Buffer refresh** — per-site data refresh without switching back to APEX.
 
 ## Technical Stuff
 
-APXM intercepts the WebSocket connection between APEX and the game server using a main-world content script injected before Prun loads. Messages are decoded through Socket.IO's double-encoding layer (engine.io + socket.io framing) and fed into typed Zustand stores. The React UI (mobile) and postMessage bridge (desktop) render from those stores.
+APXM intercepts the WebSocket connection between APEX and the game server using a main-world content script injected before Prun loads. Messages are decoded through Socket.IO's double-encoding layer (engine.io + socket.io framing) and fed into typed Zustand stores. The React overlay renders from those stores.
 
-The interception and message bus code lives in the [@prun/link](https://github.com/Zillatron27/PrUn-Link) library.
+The interception and message bus code lives in `@prun/link`, a shared library from the 27Bit toolset (currently private).
 
 ```
 APEX <-> Game Server (WebSocket/Socket.IO)
@@ -30,33 +32,36 @@ APEX <-> Game Server (WebSocket/Socket.IO)
           |
      Zustand stores
           |
-     ├── APXM React UI (mobile)
-     └── postMessage bridge → Helm shell (desktop)
+     APXM React UI
 ```
+
+APXM observes and displays — it never sends messages to the game server.
 
 ## Platforms
 
-| Platform | Browser 
-|----------|---------|
-| iOS / iPadOS | Orion (Kagi) |
-| Android | Firefox |
-| Desktop | Chrome / Firefox | Desktop view active, mobile view can be enabled with `?apxm_force` |
+| Platform | Browser | Notes |
+|----------|---------|-------|
+| iOS / iPadOS | Orion (Kagi) | Validated — install via the AMO listing |
+| Android | Firefox | |
+| Desktop | Chrome / Firefox | Dormant by default (APXM is a mobile tool); enable with `?apxm_force` |
 
 ## Install
 
-Firefox: [Firefox Add-ons (AMO)](https://addons.mozilla.org/en-US/firefox/addon/apxm/).
+Firefox (Android & desktop) and Orion (iOS): [Firefox Add-ons (AMO)](https://addons.mozilla.org/en-US/firefox/addon/apxm/).
 
-Chrome: available soon on the Chrome Web Store.
+Chrome: not yet on the Chrome Web Store.
 
 ## Build From Source
 
 Requires Node.js 22+ and pnpm 10+.
 
+> **Note:** the `@prun/link` dependency is currently a private repository, so building from source is limited to collaborators for now. The AMO listing includes the reviewed source bundle for each release.
+
 ```bash
 pnpm install
 pnpm run build            # Chrome MV3 -> .output/chrome-mv3/
 pnpm run build:firefox    # Firefox MV2 -> .output/firefox-mv2/
-pnpm run test             # Run test suite (303 tests)
+pnpm run test             # Run test suite
 ```
 
 ### Development
@@ -64,17 +69,6 @@ pnpm run test             # Run test suite (303 tests)
 ```bash
 pnpm run dev              # Chrome with hot reload
 pnpm run dev:firefox      # Firefox with hot reload
-```
-
-### Desktop Shell (apxm.27bit.dev)
-
-The desktop view shell page is a separate Vite app deployed to Cloudflare:
-
-```bash
-cd shell
-pnpm install
-pnpm run build            # Build to shell/dist/
-npx wrangler deploy       # Deploy to Cloudflare
 ```
 
 ### Package for Distribution
@@ -91,8 +85,7 @@ Found a bug or have a feature idea? [Open an issue](https://github.com/Zillatron
 ## Tech Stack
 
 - [WXT](https://wxt.dev) — cross-browser extension framework (Vite-based)
-- [Helm](https://helm.27bit.dev) — interactive galaxy map (Pixi.js)
-- [@prun/link](https://github.com/Zillatron27/PrUn-Link) — shared WebSocket interception library
+- `@prun/link` — shared WebSocket interception library (private)
 - React 19 + TypeScript
 - Zustand — state management
 - Tailwind CSS — mobile-first styling
@@ -104,8 +97,9 @@ APXM is inspired by and built on the shoulders of giants — it wouldn't exist w
 
 **[Refined PrUn (rprun)](https://github.com/refined-prun/refined-prun)** — APXM's understanding of APEX's internal message protocol, DOM structure, and buffer management draws from rprun's prior work.
 
-**[FIO (Prosperous Universe Community API)](https://doc.fnar.net)** — FIO provides the game data (materials, buildings, recipes, planet data, exchange prices) that makes tools like APXM, Helm and others possible.
+**[jackinabox86](https://github.com/jackinabox86)** — the repair and production status engines are adapted from his APXM fork.
 
+**[FIO (Prosperous Universe Community API)](https://doc.fnar.net)** — FIO provides the game data (materials, buildings, recipes, planet data, exchange prices) that makes tools like APXM, Helm and others possible.
 
 ## License
 


### PR DESCRIPTION
README still described the retired desktop view (PR #23, 2026-06-06). This brings it in line with reality:

- Desktop remnants removed: postMessage→Helm-shell in the arch diagram, desktop shell build/deploy section, broken desktop platforms-table row
- Features updated for everything shipped since: BASE status (BURN/REPAIR/PROD + indicator filters), UI themes, company & liquidity, staleness indicators
- Install: AMO listing is live (was "available soon"); Orion installs via AMO noted
- `@prun/link` de-linked (private repo) and the build-from-source limitation stated honestly
- jackinabox86 added to acknowledgments (repair/prod engines adapted from his fork)
- Helm dropped from the tech stack list (that was a desktop-view relationship)

🤖 Generated with [Claude Code](https://claude.com/claude-code)