### PR TITLE
feat(bases): empire-wide burn aggregation — SITES/EMPIRE toggle

### DIFF
--- a/components/burn/EmpireBurnList.tsx
+++ b/components/burn/EmpireBurnList.tsx
@@ -1,0 +1,57 @@
+import type { BurnRate } from '../../core/burn';
+import { BurnRow } from './BurnRow';
+import { DataSourceBadge } from './DataSourceBadge';
+import { SectionHeader } from '../shared';
+import { useSettingsStore } from '../../stores/settings';
+import {
+  useSiteSourceStore,
+  deriveWeakestSource,
+  deriveOldestUpdate,
+} from '../../stores/site-data-sources';
+
+interface EmpireBurnListProps {
+  rows: BurnRate[];
+}
+
+/**
+ * Empire-wide material list: one row per material, aggregated across all
+ * sites. The header carries a weakest-link staleness badge — the aggregate
+ * is only as fresh as the stalest site feeding it.
+ */
+export function EmpireBurnList({ rows }: EmpireBurnListProps) {
+  const siteEntries = useSiteSourceStore((s) => s.entries);
+  const fioLastFetch = useSettingsStore((s) => s.fio.lastFetch);
+  const source = deriveWeakestSource(siteEntries);
+  const oldestUpdate = deriveOldestUpdate(siteEntries);
+  const lastUpdated = source === 'fio' ? fioLastFetch : oldestUpdate;
+
+  return (
+    <div className="bg-apxm-surface p-3">
+      <SectionHeader
+        title="Empire"
+        accessory={<DataSourceBadge source={source} lastUpdated={lastUpdated} />}
+      />
+      {rows.length === 0 ? (
+        <p className="text-sm text-apxm-muted py-4 text-center">
+          No materials match the selected filter
+        </p>
+      ) : (
+        <div className="divide-y divide-apxm-bg/50">
+          {/* Column headers — same layout as the per-site card rows */}
+          <div className="flex items-center justify-between gap-1 py-1 text-[10px] text-apxm-text/40 uppercase tracking-wide">
+            <span className="w-10">Mat</span>
+            <div className="flex items-center">
+              <span className="w-12 text-right">Inv</span>
+              <span className="w-20 text-right">Rate</span>
+              <span className="w-14 text-right">Days</span>
+              <span className="w-12 text-right">Need</span>
+            </div>
+          </div>
+          {rows.map((row) => (
+            <BurnRow key={row.materialTicker} burn={row} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/burn/index.ts
+++ b/components/burn/index.ts
@@ -1,6 +1,7 @@
 export { BurnBadge, getUrgencyColor, getUrgencyTextColor } from './BurnBadge';
 export { BurnRow, BurnRowCompact } from './BurnRow';
 export { SiteBurnCard } from './SiteBurnCard';
+export { EmpireBurnList } from './EmpireBurnList';
 export { BurnSummaryList, BurnSummaryCompact } from './BurnSummaryList';
 export { useSiteBurns, sortByUrgency } from './useSiteBurns';
 export { DataSourceBadge } from './DataSourceBadge';

--- a/components/views/BasesView.tsx
+++ b/components/views/BasesView.tsx
@@ -1,10 +1,11 @@
 import { useMemo } from 'react';
 import { FilterBar, type FilterOption, DataGate, type RequiredStore } from '../shared';
 import { SiteBurnCard } from '../burn/SiteBurnCard';
+import { EmpireBurnList } from '../burn/EmpireBurnList';
 import { useRepairStatus, useProdStatuses } from '../burn';
-import { useFilteredBurns, type BurnFilter } from './hooks';
+import { useFilteredBurns, useEmpireBurn, type BurnFilter } from './hooks';
 import { useSitesStore } from '../../stores/entities/sites';
-import { useGameState } from '../../stores/gameState';
+import { useGameState, type BasesViewMode } from '../../stores/gameState';
 
 // UI label mapping: internal type → display
 const filterLabels: Record<BurnFilter, string> = {
@@ -13,6 +14,11 @@ const filterLabels: Record<BurnFilter, string> = {
   ok: 'GREEN',
   all: 'ALL',
 };
+
+const viewModes: { id: BasesViewMode; label: string }[] = [
+  { id: 'sites', label: 'SITES' },
+  { id: 'empire', label: 'EMPIRE' },
+];
 
 /**
  * Full burn view showing all sites with filtering by urgency.
@@ -23,6 +29,8 @@ export function BasesView() {
   // the toggle rules (ALL reset, empty→ALL, full-set→ALL) live with it.
   const activeFilters = useGameState((s) => s.burnFilters);
   const toggleBurnFilter = useGameState((s) => s.toggleBurnFilter);
+  const viewMode = useGameState((s) => s.basesViewMode);
+  const setBasesViewMode = useGameState((s) => s.setBasesViewMode);
   const repairStatuses = useRepairStatus();
   const prodStatuses = useProdStatuses();
   const repairBySite = useMemo(
@@ -31,7 +39,11 @@ export function BasesView() {
   );
   // Filter tiers are worst-of-three (burn/repair/prod, #37), so the maps
   // feeding the card indicators also feed the filter classification.
-  const { summaries, counts } = useFilteredBurns(activeFilters, repairBySite, prodStatuses);
+  // Both mode hooks run unconditionally (hooks rules); they share the
+  // memoized useSiteBurns inputs, so the idle one costs a single pass.
+  const { summaries, counts: siteCounts } = useFilteredBurns(activeFilters, repairBySite, prodStatuses);
+  const empire = useEmpireBurn(activeFilters);
+  const counts = viewMode === 'empire' ? empire.counts : siteCounts;
 
   const sitesFetched = useSitesStore((s) => s.fetched);
 
@@ -53,9 +65,29 @@ export function BasesView() {
   return (
     <DataGate requiredStores={requiredStores}>
       <div className="space-y-3">
+        {/* SITES / EMPIRE mode segment — heavier weight than the filter row
+            below so the two button rows read as different controls */}
+        <div className="flex gap-4 text-xs font-mono font-semibold">
+          {viewModes.map((mode) => (
+            <button
+              key={mode.id}
+              onClick={() => setBasesViewMode(mode.id)}
+              className={`pb-1 transition-colors ${
+                viewMode === mode.id
+                  ? 'text-prun-yellow border-b border-prun-yellow'
+                  : 'text-apxm-text/70 hover:text-apxm-text'
+              }`}
+            >
+              {mode.label}
+            </button>
+          ))}
+        </div>
+
         <FilterBar options={filterOptions} activeFilters={activeFilters} onChange={toggleBurnFilter} />
 
-        {summaries.length === 0 ? (
+        {viewMode === 'empire' ? (
+          <EmpireBurnList rows={empire.rows} />
+        ) : summaries.length === 0 ? (
           <p className="text-sm text-apxm-muted py-4 text-center">
             No bases match the selected filter
           </p>

--- a/components/views/hooks/__tests__/useEmpireBurn.test.ts
+++ b/components/views/hooks/__tests__/useEmpireBurn.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { sortEmpireRows } from '../useEmpireBurn';
+import type { BurnRate } from '../../../../core/burn';
+
+function makeRate(
+  overrides: Partial<BurnRate> & { materialTicker: string }
+): BurnRate {
+  return {
+    dailyAmount: 0,
+    type: 'workforce',
+    productionInput: 0,
+    productionOutput: 0,
+    workforceConsumption: 0,
+    inventoryAmount: 0,
+    daysRemaining: Infinity,
+    need: 0,
+    urgency: 'ok',
+    ...overrides,
+  };
+}
+
+describe('sortEmpireRows', () => {
+  it('sorts consuming materials first by days remaining, then surplus alphabetically', () => {
+    const rows = sortEmpireRows([
+      makeRate({ materialTicker: 'ZZZ', dailyAmount: 5, inventoryAmount: 1 }),
+      makeRate({ materialTicker: 'DW', dailyAmount: -2, daysRemaining: 10, inventoryAmount: 20 }),
+      makeRate({ materialTicker: 'AAA', dailyAmount: 3, inventoryAmount: 1 }),
+      makeRate({ materialTicker: 'RAT', dailyAmount: -4, daysRemaining: 2, inventoryAmount: 8 }),
+    ]);
+
+    expect(rows.map((r) => r.materialTicker)).toEqual(['RAT', 'DW', 'AAA', 'ZZZ']);
+  });
+
+  it('drops inactive rows (no stock, no rate, no need)', () => {
+    const rows = sortEmpireRows([
+      makeRate({ materialTicker: 'IDLE' }),
+      makeRate({ materialTicker: 'STOCKED', inventoryAmount: 5 }),
+      makeRate({ materialTicker: 'NEEDED', need: 12 }),
+    ]);
+
+    expect(rows.map((r) => r.materialTicker)).toEqual(['NEEDED', 'STOCKED']);
+  });
+
+  it('does not mutate its input', () => {
+    const input = [
+      makeRate({ materialTicker: 'B', dailyAmount: -1, daysRemaining: 1, inventoryAmount: 1 }),
+      makeRate({ materialTicker: 'A', dailyAmount: -1, daysRemaining: 0.5, inventoryAmount: 1 }),
+    ];
+    sortEmpireRows(input);
+    expect(input.map((r) => r.materialTicker)).toEqual(['B', 'A']);
+  });
+});

--- a/components/views/hooks/index.ts
+++ b/components/views/hooks/index.ts
@@ -1,4 +1,5 @@
 export { useFilteredBurns, type BurnFilter, type FilteredBurnsResult } from './useFilteredBurns';
+export { useEmpireBurn, sortEmpireRows, type EmpireBurnResult } from './useEmpireBurn';
 export {
   useFleetDetails,
   type FleetFilter,

--- a/components/views/hooks/useEmpireBurn.ts
+++ b/components/views/hooks/useEmpireBurn.ts
@@ -1,0 +1,61 @@
+import { useMemo } from 'react';
+import { useSiteBurns } from '../../burn/useSiteBurns';
+import { aggregateEmpireBurn, type BurnRate } from '../../../core/burn';
+import { useSettingsStore } from '../../../stores/settings';
+import { getFilterForUrgency } from './useFilteredBurns';
+import type { BurnFilter } from '../../../stores/gameState';
+
+export interface EmpireBurnResult {
+  /** Aggregated material rows, filtered and sorted for display. */
+  rows: BurnRate[];
+  /** Per-material tier counts for the filter bar (surplus folds into ok). */
+  counts: Record<BurnFilter, number>;
+}
+
+/**
+ * Drops inactive rows (no stock, no rate, no need) and sorts consuming
+ * materials first by days remaining, then surplus alphabetically — the
+ * same ordering as the per-site card, so both BASES modes read alike.
+ */
+export function sortEmpireRows(rows: BurnRate[]): BurnRate[] {
+  return rows
+    .filter((r) => r.inventoryAmount > 0 || r.dailyAmount !== 0 || r.need > 0)
+    .sort((a, b) => {
+      const aConsuming = a.dailyAmount < 0;
+      const bConsuming = b.dailyAmount < 0;
+      if (aConsuming !== bConsuming) return aConsuming ? -1 : 1;
+      if (aConsuming && bConsuming) return a.daysRemaining - b.daysRemaining;
+      return a.materialTicker.localeCompare(b.materialTicker);
+    });
+}
+
+/**
+ * Empire-wide burn rollup for the BASES tab's EMPIRE mode: one row per
+ * material across all sites, filtered by the shared urgency selection.
+ */
+export function useEmpireBurn(
+  activeFilters: ReadonlySet<BurnFilter>
+): EmpireBurnResult {
+  const summaries = useSiteBurns();
+  const thresholds = useSettingsStore((s) => s.burnThresholds);
+
+  return useMemo(() => {
+    const sorted = sortEmpireRows(aggregateEmpireBurn(summaries, thresholds));
+
+    const counts: Record<BurnFilter, number> = {
+      all: sorted.length,
+      critical: 0,
+      warning: 0,
+      ok: 0,
+    };
+    for (const row of sorted) {
+      counts[getFilterForUrgency(row.urgency)]++;
+    }
+
+    const rows = activeFilters.has('all')
+      ? sorted
+      : sorted.filter((r) => activeFilters.has(getFilterForUrgency(r.urgency)));
+
+    return { rows, counts };
+  }, [summaries, thresholds, activeFilters]);
+}

--- a/core/__tests__/burn.test.ts
+++ b/core/__tests__/burn.test.ts
@@ -13,8 +13,10 @@ import {
   findMostUrgent,
   calculateSiteBurn,
   calculateAllBurns,
+  aggregateEmpireBurn,
   type BurnRate,
   type BurnThresholds,
+  type SiteBurnSummary,
 } from '../burn';
 import { useSettingsStore } from '../../stores/settings';
 import { useSitesStore } from '../../stores/entities/sites';
@@ -38,6 +40,7 @@ import {
   createOrderWithIO,
   createDateTime,
 } from '../../__tests__/fixtures/factories';
+import { createEmpireFixture } from '../../__tests__/fixtures/empire';
 import type { WorkforceEntity } from '../../stores/entities/workforce';
 
 const MS_PER_DAY = 86400000;
@@ -1323,6 +1326,248 @@ describe('burn.ts', () => {
     it('returns empty array when no sites exist', () => {
       const results = calculateAllBurns();
       expect(results).toEqual([]);
+    });
+  });
+
+  describe('aggregateEmpireBurn', () => {
+    const thresholds: BurnThresholds = { critical: 3, warning: 5, resupply: 30 };
+
+    /**
+     * Aggregation reads only the component fields (rates, inventory, name)
+     * and recomputes the derived ones, so fixtures only set components.
+     */
+    function makeRate(
+      overrides: Partial<BurnRate> & { materialTicker: string }
+    ): BurnRate {
+      return {
+        dailyAmount: 0,
+        type: 'workforce',
+        productionInput: 0,
+        productionOutput: 0,
+        workforceConsumption: 0,
+        inventoryAmount: 0,
+        daysRemaining: Infinity,
+        need: 0,
+        urgency: 'ok',
+        ...overrides,
+      };
+    }
+
+    function makeSummary(siteId: string, burns: BurnRate[]): SiteBurnSummary {
+      return {
+        siteId,
+        siteName: siteId,
+        burns,
+        mostUrgent: null,
+        lastCalculated: 0,
+      };
+    }
+
+    it('returns empty array for no sites', () => {
+      expect(aggregateEmpireBurn([], thresholds)).toEqual([]);
+    });
+
+    it('computes daysRemaining from summed inventory and rate, not averaged per-site days', () => {
+      // Site A: 10 DW at 2/d = 5 days. Site B: 100 DW at 1/d = 100 days.
+      // Empire: 110 DW at 3/d ≈ 36.67 days (an average would give 52.5).
+      const rows = aggregateEmpireBurn(
+        [
+          makeSummary('a', [
+            makeRate({ materialTicker: 'DW', workforceConsumption: 2, inventoryAmount: 10 }),
+          ]),
+          makeSummary('b', [
+            makeRate({ materialTicker: 'DW', workforceConsumption: 1, inventoryAmount: 100 }),
+          ]),
+        ],
+        thresholds
+      );
+
+      expect(rows).toHaveLength(1);
+      const dw = rows[0];
+      expect(dw.materialTicker).toBe('DW');
+      expect(dw.dailyAmount).toBe(-3);
+      expect(dw.inventoryAmount).toBe(110);
+      expect(dw.daysRemaining).toBeCloseTo(110 / 3, 5);
+      expect(dw.urgency).toBe('ok');
+    });
+
+    it('classifies a cross-site flow that nets to zero as surplus with no need', () => {
+      // Producer covers the consumer exactly — empire-wide, nothing to buy.
+      const rows = aggregateEmpireBurn(
+        [
+          makeSummary('producer', [
+            makeRate({ materialTicker: 'RAT', productionOutput: 10 }),
+          ]),
+          makeSummary('consumer', [
+            makeRate({ materialTicker: 'RAT', workforceConsumption: 10 }),
+          ]),
+        ],
+        thresholds
+      );
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].dailyAmount).toBe(0);
+      expect(rows[0].daysRemaining).toBe(Infinity);
+      expect(rows[0].urgency).toBe('surplus');
+      expect(rows[0].need).toBe(0);
+    });
+
+    it('classifies a net-produced material as surplus (valid per-material at empire level)', () => {
+      const rows = aggregateEmpireBurn(
+        [
+          makeSummary('producer', [
+            makeRate({ materialTicker: 'GRN', productionOutput: 10 }),
+          ]),
+          makeSummary('consumer', [
+            makeRate({ materialTicker: 'GRN', productionInput: 4 }),
+          ]),
+        ],
+        thresholds
+      );
+
+      expect(rows[0].dailyAmount).toBe(6);
+      expect(rows[0].urgency).toBe('surplus');
+    });
+
+    it('treats near-zero net rates as floating-point noise, not consumption or surplus', () => {
+      // Imbalance below NET_RATE_EPSILON: no runout, but net is still
+      // negative so it must not read as surplus either.
+      const rows = aggregateEmpireBurn(
+        [
+          makeSummary('producer', [
+            makeRate({ materialTicker: 'AL', productionOutput: 10 }),
+          ]),
+          makeSummary('consumer', [
+            makeRate({ materialTicker: 'AL', productionInput: 10.0005 }),
+          ]),
+        ],
+        thresholds
+      );
+
+      expect(rows[0].daysRemaining).toBe(Infinity);
+      expect(rows[0].urgency).toBe('ok');
+    });
+
+    it('recomputes need at empire level: a producing site offsets consumers', () => {
+      // Site A consumes 2/d with nothing stocked → site-level need is 60
+      // (30-day resupply). Site B produces 1/d. Empire net is only -1/d,
+      // so the empire need is 30 — less than the per-site sum.
+      const rows = aggregateEmpireBurn(
+        [
+          makeSummary('a', [
+            makeRate({ materialTicker: 'COF', workforceConsumption: 2, need: 60 }),
+          ]),
+          makeSummary('b', [
+            makeRate({ materialTicker: 'COF', productionOutput: 1 }),
+          ]),
+        ],
+        thresholds
+      );
+
+      expect(rows[0].dailyAmount).toBe(-1);
+      expect(rows[0].need).toBe(30);
+    });
+
+    it('classifies type from aggregated sums', () => {
+      const rows = aggregateEmpireBurn(
+        [
+          makeSummary('a', [
+            makeRate({ materialTicker: 'RAT', productionOutput: 5 }),
+            makeRate({ materialTicker: 'H2O', productionInput: 3 }),
+          ]),
+          makeSummary('b', [
+            makeRate({ materialTicker: 'RAT', workforceConsumption: 2 }),
+            makeRate({ materialTicker: 'H2O', workforceConsumption: 2 }),
+          ]),
+        ],
+        thresholds
+      );
+
+      const rat = rows.find((r) => r.materialTicker === 'RAT');
+      const h2o = rows.find((r) => r.materialTicker === 'H2O');
+      expect(rat?.type).toBe('output'); // net +3
+      expect(h2o?.type).toBe('input'); // net negative with production input
+    });
+
+    it('propagates the first available material name', () => {
+      const rows = aggregateEmpireBurn(
+        [
+          makeSummary('a', [
+            makeRate({ materialTicker: 'RAT', workforceConsumption: 1 }),
+          ]),
+          makeSummary('b', [
+            makeRate({
+              materialTicker: 'RAT',
+              workforceConsumption: 1,
+              materialName: 'Rations',
+            }),
+          ]),
+        ],
+        thresholds
+      );
+
+      expect(rows[0].materialName).toBe('Rations');
+    });
+
+    it('marks a consuming material with zero empire inventory as critical with 0 days', () => {
+      const rows = aggregateEmpireBurn(
+        [
+          makeSummary('a', [
+            makeRate({ materialTicker: 'DW', workforceConsumption: 4 }),
+          ]),
+        ],
+        thresholds
+      );
+
+      expect(rows[0].daysRemaining).toBe(0);
+      expect(rows[0].urgency).toBe('critical');
+      expect(rows[0].need).toBe(120); // 30 days × 4/d, nothing stocked
+    });
+
+    it('aggregates the empire fixture consistently with per-site results', () => {
+      const fixture = createEmpireFixture();
+      useSitesStore.getState().setAll(fixture.sites);
+      useStorageStore.getState().setAll(fixture.storages);
+      useWorkforceStore.getState().setAll(fixture.workforces);
+      useProductionStore.getState().setAll(fixture.productionLines);
+
+      const summaries = calculateAllBurns();
+      const rows = aggregateEmpireBurn(
+        summaries,
+        useSettingsStore.getState().burnThresholds
+      );
+
+      // DW is a workforce consumable on every base — the fixture must
+      // exercise true cross-site aggregation for it.
+      const dwSites = summaries.filter((s) =>
+        s.burns.some((b) => b.materialTicker === 'DW')
+      );
+      expect(dwSites.length).toBeGreaterThanOrEqual(2);
+
+      // Every empire row's components equal the sums of the per-site rows.
+      for (const row of rows) {
+        const siteRows = summaries.flatMap((s) =>
+          s.burns.filter((b) => b.materialTicker === row.materialTicker)
+        );
+        const sum = (pick: (b: BurnRate) => number) =>
+          siteRows.reduce((acc, b) => acc + pick(b), 0);
+
+        expect(row.workforceConsumption).toBeCloseTo(
+          sum((b) => b.workforceConsumption),
+          5
+        );
+        expect(row.productionInput).toBeCloseTo(sum((b) => b.productionInput), 5);
+        expect(row.productionOutput).toBeCloseTo(sum((b) => b.productionOutput), 5);
+        expect(row.inventoryAmount).toBeCloseTo(sum((b) => b.inventoryAmount), 5);
+      }
+
+      // And every material seen at any site appears exactly once.
+      const tickers = rows.map((r) => r.materialTicker);
+      expect(new Set(tickers).size).toBe(tickers.length);
+      const allSiteTickers = new Set(
+        summaries.flatMap((s) => s.burns.map((b) => b.materialTicker))
+      );
+      expect(new Set(tickers)).toEqual(allSiteTickers);
     });
   });
 

--- a/core/burn.ts
+++ b/core/burn.ts
@@ -86,6 +86,14 @@ interface WorkforceRateEntry {
 const MS_PER_DAY = 86400000;
 
 /**
+ * Net rates below this (units/day) are floating-point noise from balanced
+ * production chains — treat as effectively zero consumption. Shared by the
+ * site and empire paths so a chain that nets out per-site also nets out
+ * when aggregated across sites.
+ */
+const NET_RATE_EPSILON = 0.001;
+
+/**
  * Returns the orders that represent the ongoing production plan for rate calculation.
  * Started orders are excluded — when an order starts executing, its inputs are immediately
  * deducted from inventory and it's no longer part of the queue. Including them would
@@ -282,6 +290,54 @@ export function findMostUrgent(burns: BurnRate[]): BurnRate | null {
   })[0];
 }
 
+/**
+ * Builds one BurnRate from daily rates and inventory. Shared by the per-site
+ * and empire paths so both classify days remaining, urgency, and need
+ * identically.
+ */
+function buildBurnRate(
+  ticker: string,
+  materialName: string | undefined,
+  productionInput: number,
+  productionOutput: number,
+  workforceConsumption: number,
+  inventoryAmount: number,
+  thresholds: BurnThresholds
+): BurnRate {
+  // Net daily amount: positive = producing, negative = consuming
+  const dailyAmount = productionOutput - productionInput - workforceConsumption;
+
+  let daysRemaining: number;
+  if (dailyAmount >= 0 || Math.abs(dailyAmount) < NET_RATE_EPSILON) {
+    daysRemaining = Infinity;
+  } else {
+    daysRemaining =
+      inventoryAmount === 0 ? 0 : inventoryAmount / Math.abs(dailyAmount);
+  }
+
+  const type = classifyBurnType(
+    productionInput,
+    productionOutput,
+    workforceConsumption
+  );
+  const urgency = classifyUrgency(daysRemaining, dailyAmount, thresholds);
+  const need = calculateNeed(dailyAmount, inventoryAmount, thresholds.resupply);
+
+  return {
+    materialTicker: ticker,
+    materialName,
+    dailyAmount,
+    type,
+    productionInput,
+    productionOutput,
+    workforceConsumption,
+    inventoryAmount,
+    daysRemaining,
+    need,
+    urgency,
+  };
+}
+
 // ============================================================================
 // Main Entry Points
 // ============================================================================
@@ -320,51 +376,17 @@ export function calculateSiteBurn(siteId: string): SiteBurnSummary {
     const production = productionRates.get(ticker) ?? { input: 0, output: 0 };
     const workforce = workforceRates.get(ticker) ?? { consumption: 0 };
 
-    const productionInput = production.input;
-    const productionOutput = production.output;
-    const workforceConsumption = workforce.consumption;
-
-    // Net daily amount: positive = producing, negative = consuming
-    const dailyAmount =
-      productionOutput - productionInput - workforceConsumption;
-
-    const inventoryAmount = inventory.get(ticker) ?? 0;
-
-    // Days remaining calculation
-    // Near-zero net rates (< 0.001 units/day) are floating-point noise from
-    // balanced production chains — treat as effectively zero consumption.
-    let daysRemaining: number;
-    if (dailyAmount >= 0 || Math.abs(dailyAmount) < 0.001) {
-      daysRemaining = Infinity;
-    } else {
-      daysRemaining =
-        inventoryAmount === 0 ? 0 : inventoryAmount / Math.abs(dailyAmount);
-    }
-
-    const type = classifyBurnType(
-      productionInput,
-      productionOutput,
-      workforceConsumption
+    burns.push(
+      buildBurnRate(
+        ticker,
+        production.name ?? workforce.name,
+        production.input,
+        production.output,
+        workforce.consumption,
+        inventory.get(ticker) ?? 0,
+        thresholds
+      )
     );
-    const urgency = classifyUrgency(daysRemaining, dailyAmount, thresholds);
-    const need = calculateNeed(dailyAmount, inventoryAmount, thresholds.resupply);
-
-    // Get material name from either source
-    const materialName = production.name ?? workforce.name;
-
-    burns.push({
-      materialTicker: ticker,
-      materialName,
-      dailyAmount,
-      type,
-      productionInput,
-      productionOutput,
-      workforceConsumption,
-      inventoryAmount,
-      daysRemaining,
-      need,
-      urgency,
-    });
   }
 
   return {
@@ -382,4 +404,66 @@ export function calculateSiteBurn(siteId: string): SiteBurnSummary {
 export function calculateAllBurns(): SiteBurnSummary[] {
   const sites = useSitesStore.getState().getAll();
   return sites.map((site) => calculateSiteBurn(site.siteId));
+}
+
+/**
+ * Aggregates per-site burns into one empire-wide row per material.
+ *
+ * Rates and inventory are summed across sites; daysRemaining is
+ * Σinventory / |Σnet| — never an average of per-site days — and need is
+ * recomputed at the empire level, so a site producing a material offsets
+ * the sites consuming it. Unlike a site's mostUrgent, an empire row can
+ * legitimately be 'surplus': a material net-produced across the empire
+ * needs no resupply purchase.
+ *
+ * Inventory counts only sites where the material has burn activity,
+ * matching the per-site semantics (stock at an inactive site feeds no
+ * burn until it is shipped somewhere that consumes it).
+ */
+export function aggregateEmpireBurn(
+  summaries: SiteBurnSummary[],
+  thresholds: BurnThresholds
+): BurnRate[] {
+  interface MaterialTotals {
+    productionInput: number;
+    productionOutput: number;
+    workforceConsumption: number;
+    inventoryAmount: number;
+    materialName?: string;
+  }
+
+  const totals = new Map<string, MaterialTotals>();
+
+  for (const summary of summaries) {
+    for (const burn of summary.burns) {
+      const existing = totals.get(burn.materialTicker) ?? {
+        productionInput: 0,
+        productionOutput: 0,
+        workforceConsumption: 0,
+        inventoryAmount: 0,
+      };
+      existing.productionInput += burn.productionInput;
+      existing.productionOutput += burn.productionOutput;
+      existing.workforceConsumption += burn.workforceConsumption;
+      existing.inventoryAmount += burn.inventoryAmount;
+      existing.materialName = existing.materialName ?? burn.materialName;
+      totals.set(burn.materialTicker, existing);
+    }
+  }
+
+  const rows: BurnRate[] = [];
+  for (const [ticker, t] of totals) {
+    rows.push(
+      buildBurnRate(
+        ticker,
+        t.materialName,
+        t.productionInput,
+        t.productionOutput,
+        t.workforceConsumption,
+        t.inventoryAmount,
+        thresholds
+      )
+    );
+  }
+  return rows;
 }

--- a/stores/gameState.ts
+++ b/stores/gameState.ts
@@ -19,6 +19,9 @@ export type BurnFilter = Exclude<Urgency, 'surplus'> | 'all';
 export type FleetFilter = 'idle' | 'in-transit' | 'all';
 export type ContractFilter = 'active' | 'fulfilled' | 'all';
 
+/** BASES tab display mode: per-site cards or the empire-wide material rollup. */
+export type BasesViewMode = 'sites' | 'empire';
+
 // Non-ALL filter values per view, used by the toggle collapse/revert rules
 const individualBurnFilters: readonly BurnFilter[] = ['critical', 'warning', 'ok'];
 const individualFleetFilters: readonly FleetFilter[] = ['idle', 'in-transit'];
@@ -62,10 +65,14 @@ interface GameState {
   burnFilters: ReadonlySet<BurnFilter>;
   fleetFilters: ReadonlySet<FleetFilter>;
   contractFilters: ReadonlySet<ContractFilter>;
+  // Session-scoped like the filters: an EMPIRE mode that stuck across
+  // reloads would hide the per-site cards users expect to land on.
+  basesViewMode: BasesViewMode;
   setOverlayVisible: (visible: boolean) => void;
   setDebugMode: (debug: boolean) => void;
   setApexVisible: (visible: boolean) => void;
   setActiveTab: (tab: TabId) => void;
+  setBasesViewMode: (mode: BasesViewMode) => void;
   toggleBurnFilter: (filter: BurnFilter) => void;
   toggleFleetFilter: (filter: FleetFilter) => void;
   toggleContractFilter: (filter: ContractFilter) => void;
@@ -80,10 +87,12 @@ export const useGameState = create<GameState>((set) => ({
   fleetFilters: new Set<FleetFilter>(['all']),
   // Contracts default to ACTIVE — fulfilled contracts are history
   contractFilters: new Set<ContractFilter>(['active']),
+  basesViewMode: 'sites',
   setOverlayVisible: (overlayVisible) => set({ overlayVisible }),
   setDebugMode: (debugMode) => set({ debugMode }),
   setApexVisible: (apexVisible) => set({ apexVisible }),
   setActiveTab: (activeTab) => set({ activeTab }),
+  setBasesViewMode: (basesViewMode) => set({ basesViewMode }),
   toggleBurnFilter: (filter) =>
     set((state) => ({
       burnFilters: toggleFilterSelection(state.burnFilters, filter, individualBurnFilters),


### PR DESCRIPTION
Closes #4.

The BASES tab gains a **SITES / EMPIRE** mode segment. EMPIRE mode shows one aggregated row per material across all sites — summed inventory, net daily rate, days remaining, and need — answering "how much DW do I need to buy across my whole empire" without manually summing per-site needs.

**Aggregation semantics** (`aggregateEmpireBurn` in `core/burn.ts`):
- Rates and inventory are **summed** per material; `daysRemaining = Σinventory / |Σnet|` — never an average of per-site days.
- `need` is recomputed at empire level, so a site producing a material offsets the sites consuming it (empire need ≤ sum of site needs).
- Per-material **surplus is valid here** (unlike site-level mostUrgent): a material net-produced across the empire needs no purchase. Surplus folds into GREEN in the filter bar, consistent with the per-site rule from #24.
- Site and empire paths share one row builder (extracted from `calculateSiteBurn`), including the near-zero `NET_RATE_EPSILON` rule — balanced chains that net out per-site also net out across sites.
- Inventory counts only sites where the material has burn activity, matching per-site semantics (stock at an inactive site feeds no burn until shipped).

**UI:** EMPIRE reuses `BurnRow` and the per-site column layout so both modes read alike; the shared RED/YELLOW/GREEN selection filters material rows (counts switch to per-material). The header carries the weakest-link WS/FIO staleness badge — the aggregate is only as fresh as the stalest site feeding it. Mode is session-scoped like the filters.

**Tests:** 13 new (376 total), including the first consumer of the multi-base `createEmpireFixture`, cross-validating empire rows against per-site sums. `tsc --noEmit` clean; both build targets verified.

**Follow-up candidates** (not in scope): a per-material INF/surplus filter tier for EMPIRE mode; counting stock at non-consuming sites toward empire inventory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)