### PR TITLE
feat(fio): public reference data — material names + CX prices (scoped #2)

### DIFF
--- a/components/burn/BurnRow.tsx
+++ b/components/burn/BurnRow.tsx
@@ -1,21 +1,23 @@
+import { useState } from 'react';
 import type { BurnRate } from '../../core/burn';
 import { BurnBadge } from './BurnBadge';
 import { MaterialTile } from '../shared';
 
 interface BurnRowProps {
   burn: BurnRate;
-  /** Show detailed breakdown (production in/out, workforce) */
-  detailed?: boolean;
 }
 
 /**
- * Single material burn row showing ticker, days remaining, and optionally need.
+ * Single material burn row showing ticker, inventory, daily rate, days
+ * remaining, and need. Tapping expands a detail line with the full
+ * material name and the in/out/workforce rate breakdown.
  */
-export function BurnRow({ burn, detailed = false }: BurnRowProps) {
+export function BurnRow({ burn }: BurnRowProps) {
+  const [expanded, setExpanded] = useState(false);
   const {
     materialTicker,
+    materialName,
     dailyAmount,
-    type,
     urgency,
     inventoryAmount,
     daysRemaining,
@@ -28,33 +30,68 @@ export function BurnRow({ burn, detailed = false }: BurnRowProps) {
   const isConsuming = dailyAmount < 0;
   const dailyDisplay = dailyAmount >= 0 ? `+${dailyAmount.toFixed(1)}` : dailyAmount.toFixed(1);
 
+  // Only the active components — a zero line in the breakdown is noise
+  const breakdown = [
+    productionInput > 0 && `in ${productionInput.toFixed(1)}`,
+    productionOutput > 0 && `out ${productionOutput.toFixed(1)}`,
+    workforceConsumption > 0 && `wf ${workforceConsumption.toFixed(1)}`,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+
   return (
-    <div className="flex items-center justify-between gap-1 py-1">
-      {/* Ticker */}
-      <MaterialTile ticker={materialTicker} />
+    // flex-col overrides the browser's default vertical centring of button
+    // content, so the visible row keeps its position and expanding only
+    // grows the detail line downward.
+    <button
+      onClick={() => setExpanded(!expanded)}
+      aria-expanded={expanded}
+      className="w-full flex flex-col items-stretch justify-start text-left hover:bg-apxm-accent/30"
+    >
+      <div className="flex items-center justify-between gap-1 py-1">
+        {/* Ticker */}
+        <MaterialTile ticker={materialTicker} />
 
-      <div className="flex items-center">
-        {/* Inventory */}
-        <span className="w-12 text-right font-mono text-xs text-apxm-text/70">
-          {Math.floor(inventoryAmount)}
-        </span>
+        <div className="flex items-center">
+          {/* Inventory */}
+          <span className="w-12 text-right font-mono text-xs text-apxm-text/70">
+            {Math.floor(inventoryAmount)}
+          </span>
 
-        {/* Daily rate */}
-        <span className={`w-20 text-right font-mono text-xs ${isConsuming ? 'text-status-critical' : 'text-status-ok'}`}>
-          {dailyDisplay}/d
-        </span>
+          {/* Daily rate */}
+          <span className={`w-20 text-right font-mono text-xs ${isConsuming ? 'text-status-critical' : 'text-status-ok'}`}>
+            {dailyDisplay}/d
+          </span>
 
-        {/* Days remaining */}
-        <span className="w-14 text-right">
-          <BurnBadge urgency={urgency} daysRemaining={daysRemaining} />
-        </span>
+          {/* Days remaining */}
+          <span className="w-14 text-right">
+            <BurnBadge urgency={urgency} daysRemaining={daysRemaining} />
+          </span>
 
-        {/* Need amount (only if consuming and has need) */}
-        <span className="w-12 text-right text-xs text-status-warning">
-          {isConsuming && need > 0 ? `+${Math.ceil(need)}` : ''}
-        </span>
+          {/* Need amount (only if consuming and has need) */}
+          <span className="w-12 text-right text-xs text-status-warning">
+            {isConsuming && need > 0 ? `+${Math.ceil(need)}` : ''}
+          </span>
+        </div>
       </div>
-    </div>
+
+      {/* grid-rows 0fr→1fr animates to natural height (height:auto isn't
+          transitionable); motion-reduce disables it */}
+      <div
+        className={`grid transition-[grid-template-rows,opacity] duration-150 ease-out motion-reduce:transition-none ${
+          expanded ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'
+        }`}
+      >
+        <div className="overflow-hidden">
+          <div className="flex items-center justify-between gap-2 pb-1 text-[11px] text-apxm-text/50">
+            <span className="truncate">{materialName ?? materialTicker}</span>
+            {breakdown && (
+              <span className="font-mono shrink-0">{breakdown} /d</span>
+            )}
+          </div>
+        </div>
+      </div>
+    </button>
   );
 }
 

--- a/core/burn.ts
+++ b/core/burn.ts
@@ -12,6 +12,7 @@ import { getProductionBySiteId } from '../stores/entities/production';
 import { getWorkforceBySiteId } from '../stores/entities/workforce';
 import { getStorageByAddressableId } from '../stores/entities/storage';
 import { useSitesStore } from '../stores/entities/sites';
+import { getMaterialName } from '../stores/reference';
 import { getEntityDisplayName } from '../lib/address';
 
 // ============================================================================
@@ -349,8 +350,10 @@ export function calculateSiteBurn(siteId: string): SiteBurnSummary {
     const urgency = classifyUrgency(daysRemaining, dailyAmount, thresholds);
     const need = calculateNeed(dailyAmount, inventoryAmount, thresholds.resupply);
 
-    // Get material name from either source
-    const materialName = production.name ?? workforce.name;
+    // Material name from the WS/FIO payloads, falling back to the public
+    // materials database for tickers those payloads didn't name
+    const materialName =
+      production.name ?? workforce.name ?? getMaterialName(ticker);
 
     burns.push({
       materialTicker: ticker,

--- a/entrypoints/content.tsx
+++ b/entrypoints/content.tsx
@@ -6,7 +6,7 @@ import { useConnectionStore } from '../stores/connection';
 import { useSettingsStore, waitForSettingsHydration } from '../stores/settings';
 import { initMessageHandlers, processMessage } from '../stores/message-handlers';
 import { beginEntityBatch, endEntityBatch } from '../stores/entities';
-import { populateStoresFromFio } from '../lib/fio';
+import { populateStoresFromFio, ensureReferenceData } from '../lib/fio';
 import { rehydrateAllStores } from '../stores/cache';
 import { warn, error as logError } from '../lib/debug/logger';
 import { isDebugEnabled, createOverlay, markStep, markFailed, pollForAttribute, ensureDiagnosticsVisible } from '../lib/diagnostics';
@@ -164,7 +164,13 @@ export default defineContentScript({
       );
     }
 
-    // 6b. FIO fetch (fire-and-forget, concurrent with React mount)
+    // 6b. Public reference data — material names, CX prices. No credentials
+    // involved, so this runs regardless of the FIO account config below.
+    // Within cache TTL the rehydration above already populated the stores
+    // and this is a no-op.
+    void ensureReferenceData();
+
+    // 6c. FIO fetch (fire-and-forget, concurrent with React mount)
     const settings = useSettingsStore.getState();
     if (settings.fio.apiKey && settings.fio.username) {
       populateStoresFromFio({

--- a/lib/fio/__tests__/client.test.ts
+++ b/lib/fio/__tests__/client.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fetchAllMaterials, fetchExchangeAll } from '../client';
+
+/**
+ * The public-endpoint contract: correct paths, NO Authorization header
+ * (reference data must work without a configured FIO account), and
+ * HTTP failures mapped to error results instead of throws.
+ */
+describe('FIO public client', () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function okResponse(data: unknown): Response {
+    return {
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(data),
+    } as unknown as Response;
+  }
+
+  it('fetchAllMaterials hits /material/allmaterials without an Authorization header', async () => {
+    fetchMock.mockResolvedValue(okResponse([]));
+
+    const result = await fetchAllMaterials();
+
+    expect(result.ok).toBe(true);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://rest.fnar.net/material/allmaterials',
+      expect.objectContaining({ method: 'GET' })
+    );
+    const headers = fetchMock.mock.calls[0][1].headers;
+    expect(headers).not.toHaveProperty('Authorization');
+  });
+
+  it('fetchExchangeAll hits /exchange/all without an Authorization header', async () => {
+    fetchMock.mockResolvedValue(okResponse([]));
+
+    await fetchExchangeAll();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://rest.fnar.net/exchange/all',
+      expect.objectContaining({ method: 'GET' })
+    );
+    expect(fetchMock.mock.calls[0][1].headers).not.toHaveProperty('Authorization');
+  });
+
+  it('maps a non-OK status to an error result instead of throwing', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    } as unknown as Response);
+
+    const result = await fetchAllMaterials();
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe('unknown');
+      expect(result.error.message).toContain('500');
+    }
+  });
+
+  it('maps a network failure to an error result instead of throwing', async () => {
+    fetchMock.mockRejectedValue(new Error('connection refused'));
+
+    const result = await fetchExchangeAll();
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe('network');
+      expect(result.error.message).toBe('connection refused');
+    }
+  });
+});

--- a/lib/fio/__tests__/reference.test.ts
+++ b/lib/fio/__tests__/reference.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ensureReferenceData } from '../reference';
+import { fetchAllMaterials, fetchExchangeAll } from '../client';
+import { useMaterialsStore, useCxStore } from '../../../stores/reference';
+import type { FioMaterial, FioExchangeEntry } from '../types';
+
+vi.mock('../client', () => ({
+  fetchAllMaterials: vi.fn(),
+  fetchExchangeAll: vi.fn(),
+}));
+
+const fetchAllMaterialsMock = vi.mocked(fetchAllMaterials);
+const fetchExchangeAllMock = vi.mocked(fetchExchangeAll);
+
+const fioMaterial: FioMaterial = {
+  MaterialId: 'mat-rat',
+  CategoryName: 'consumables (basic)',
+  CategoryId: 'cat-1',
+  Name: 'Rations',
+  Ticker: 'RAT',
+  Weight: 0.21,
+  Volume: 0.1,
+};
+
+const fioExchangeEntry: FioExchangeEntry = {
+  MaterialTicker: 'RAT',
+  ExchangeCode: 'AI1',
+  MMBuy: null,
+  MMSell: null,
+  PriceAverage: 105.5,
+  AskCount: 12,
+  Ask: 110,
+  Supply: 5000,
+  BidCount: 8,
+  Bid: 101,
+  Demand: 3200,
+};
+
+describe('ensureReferenceData', () => {
+  beforeEach(() => {
+    useMaterialsStore.getState().clear();
+    useCxStore.getState().clear();
+    fetchAllMaterialsMock.mockReset();
+    fetchExchangeAllMock.mockReset();
+  });
+
+  it('populates both empty stores and marks them fio-sourced', async () => {
+    fetchAllMaterialsMock.mockResolvedValue({ ok: true, data: [fioMaterial] });
+    fetchExchangeAllMock.mockResolvedValue({ ok: true, data: [fioExchangeEntry] });
+
+    await ensureReferenceData();
+
+    expect(useMaterialsStore.getState().fetched).toBe(true);
+    expect(useMaterialsStore.getState().dataSource).toBe('fio');
+    expect(useMaterialsStore.getState().getById('RAT')?.name).toBe('Rations');
+    expect(useCxStore.getState().fetched).toBe(true);
+    expect(useCxStore.getState().getById('RAT.AI1')?.priceAverage).toBe(105.5);
+  });
+
+  it('skips stores that are already populated (e.g. fresh cache rehydration)', async () => {
+    useMaterialsStore.getState().setAll([
+      { ticker: 'RAT', name: 'Rations', category: '', weight: 0, volume: 0 },
+    ]);
+    useMaterialsStore.getState().setFetched('cache');
+    fetchExchangeAllMock.mockResolvedValue({ ok: true, data: [fioExchangeEntry] });
+
+    await ensureReferenceData();
+
+    expect(fetchAllMaterialsMock).not.toHaveBeenCalled();
+    expect(fetchExchangeAllMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('one endpoint failing does not block the other', async () => {
+    fetchAllMaterialsMock.mockResolvedValue({
+      ok: false,
+      error: { type: 'network', message: 'offline' },
+    });
+    fetchExchangeAllMock.mockResolvedValue({ ok: true, data: [fioExchangeEntry] });
+
+    await ensureReferenceData();
+
+    expect(useMaterialsStore.getState().fetched).toBe(false);
+    expect(useCxStore.getState().fetched).toBe(true);
+  });
+
+  it('a failed store stays unfetched so the next call retries it', async () => {
+    fetchAllMaterialsMock.mockResolvedValue({
+      ok: false,
+      error: { type: 'network', message: 'offline' },
+    });
+    fetchExchangeAllMock.mockResolvedValue({
+      ok: false,
+      error: { type: 'unknown', message: 'HTTP 500' },
+    });
+
+    await expect(ensureReferenceData()).resolves.toBeUndefined();
+
+    fetchAllMaterialsMock.mockResolvedValue({ ok: true, data: [fioMaterial] });
+    fetchExchangeAllMock.mockResolvedValue({ ok: true, data: [fioExchangeEntry] });
+
+    await ensureReferenceData();
+
+    expect(useMaterialsStore.getState().fetched).toBe(true);
+    expect(useCxStore.getState().fetched).toBe(true);
+  });
+});

--- a/lib/fio/__tests__/transforms.test.ts
+++ b/lib/fio/__tests__/transforms.test.ts
@@ -8,12 +8,16 @@ import {
   transformAllStorage,
   transformSite,
   transformAllSites,
+  transformAllMaterials,
+  transformAllExchange,
 } from '../transforms';
 import type {
   FioWorkforce,
   FioProductionLine,
   FioStorage,
   FioSite,
+  FioMaterial,
+  FioExchangeEntry,
 } from '../types';
 
 describe('FIO Transforms', () => {
@@ -418,5 +422,92 @@ describe('FIO boundary validation', () => {
     const result = transformAllWorkforce([validWorkforce, malformed]);
     expect(result).toHaveLength(1);
     expect(result[0].siteId).toBe('site-1');
+  });
+});
+
+describe('FIO reference data transforms', () => {
+  const validMaterial: FioMaterial = {
+    MaterialId: 'mat-rat',
+    CategoryName: 'consumables (basic)',
+    CategoryId: 'cat-1',
+    Name: 'Rations',
+    Ticker: 'RAT',
+    Weight: 0.21,
+    Volume: 0.1,
+  };
+
+  const validExchangeEntry: FioExchangeEntry = {
+    MaterialTicker: 'RAT',
+    ExchangeCode: 'AI1',
+    MMBuy: null,
+    MMSell: null,
+    PriceAverage: 105.5,
+    AskCount: 12,
+    Ask: 110,
+    Supply: 5000,
+    BidCount: 8,
+    Bid: 101,
+    Demand: 3200,
+  };
+
+  describe('transformAllMaterials', () => {
+    it('maps a valid material record', () => {
+      const result = transformAllMaterials([validMaterial]);
+      expect(result).toEqual([
+        {
+          ticker: 'RAT',
+          name: 'Rations',
+          category: 'consumables (basic)',
+          weight: 0.21,
+          volume: 0.1,
+        },
+      ]);
+    });
+
+    it('returns an empty array when the response is not an array', () => {
+      expect(transformAllMaterials(null)).toEqual([]);
+      expect(transformAllMaterials({ not: 'an array' })).toEqual([]);
+    });
+
+    it('skips a record missing its identity fields but keeps valid siblings', () => {
+      // Flat records can't throw on field access, so the transform must
+      // validate Ticker/Name itself for the skip path to work at all.
+      const missingTicker = { ...validMaterial, Ticker: undefined };
+      const missingName = { ...validMaterial, Name: 42 };
+      const result = transformAllMaterials([missingTicker, validMaterial, missingName]);
+      expect(result).toHaveLength(1);
+      expect(result[0].ticker).toBe('RAT');
+    });
+  });
+
+  describe('transformAllExchange', () => {
+    it('maps a valid exchange entry, preserving nullable market fields', () => {
+      const result = transformAllExchange([validExchangeEntry]);
+      expect(result).toEqual([
+        {
+          ticker: 'RAT',
+          exchangeCode: 'AI1',
+          bid: 101,
+          ask: 110,
+          priceAverage: 105.5,
+          supply: 5000,
+          demand: 3200,
+          mmBuy: null,
+          mmSell: null,
+        },
+      ]);
+    });
+
+    it('returns an empty array when the response is not an array', () => {
+      expect(transformAllExchange(undefined)).toEqual([]);
+      expect(transformAllExchange('nope')).toEqual([]);
+    });
+
+    it('skips a record missing ticker or exchange code but keeps valid siblings', () => {
+      const missingCode = { ...validExchangeEntry, ExchangeCode: null };
+      const result = transformAllExchange([validExchangeEntry, missingCode]);
+      expect(result).toHaveLength(1);
+      expect(result[0].exchangeCode).toBe('AI1');
+    });
   });
 });

--- a/lib/fio/client.ts
+++ b/lib/fio/client.ts
@@ -12,6 +12,8 @@ import type {
   FioProductionLine,
   FioStorage,
   FioSite,
+  FioMaterial,
+  FioExchangeEntry,
 } from './types';
 
 const FIO_BASE_URL = 'https://rest.fnar.net';
@@ -62,6 +64,41 @@ async function fioFetch<T>(
     const message = err instanceof Error ? err.message : 'Unknown network error';
     return { ok: false, error: { type: 'network', message } };
   }
+}
+
+/**
+ * Makes an anonymous GET request to a public FIO endpoint.
+ * Reference data (materials, exchange prices) needs no Authorization
+ * header, so these requests work without a configured FIO account.
+ */
+async function fioFetchPublic<T>(endpoint: string): Promise<FioResult<T>> {
+  try {
+    const response = await fetch(`${FIO_BASE_URL}${endpoint}`, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+      },
+    });
+    return handleResponse<T>(response);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown network error';
+    return { ok: false, error: { type: 'network', message } };
+  }
+}
+
+/**
+ * Fetches the full materials database (public reference data).
+ */
+export async function fetchAllMaterials(): Promise<FioResult<FioMaterial[]>> {
+  return fioFetchPublic<FioMaterial[]>('/material/allmaterials');
+}
+
+/**
+ * Fetches simplified market data for all materials on all exchanges
+ * (public; FIO caches this server-side for ~15 minutes).
+ */
+export async function fetchExchangeAll(): Promise<FioResult<FioExchangeEntry[]>> {
+  return fioFetchPublic<FioExchangeEntry[]>('/exchange/all');
 }
 
 /**

--- a/lib/fio/index.ts
+++ b/lib/fio/index.ts
@@ -1,5 +1,6 @@
 // FIO API module exports
 
-export { fetchWorkforce, fetchProduction, fetchStorage, fetchSites, testConnection } from './client';
+export { fetchWorkforce, fetchProduction, fetchStorage, fetchSites, fetchAllMaterials, fetchExchangeAll, testConnection } from './client';
 export { populateStoresFromFio, type PopulateResult, type FioProgressStep } from './populate-stores';
+export { ensureReferenceData } from './reference';
 export type { FioConfig, FioResult, FioError, FioErrorType } from './types';

--- a/lib/fio/reference.ts
+++ b/lib/fio/reference.ts
@@ -1,0 +1,41 @@
+/**
+ * FIO Public Reference Data Coordinator
+ *
+ * Populates the materials and CX reference stores from FIO's public
+ * (no-auth) endpoints at startup.
+ */
+
+import { fetchAllMaterials, fetchExchangeAll } from './client';
+import { transformAllMaterials, transformAllExchange } from './transforms';
+import { useMaterialsStore, useCxStore } from '../../stores/reference';
+import { warn } from '../debug/logger';
+
+/**
+ * Fetches public reference data for any store not already populated — a
+ * fresh cache rehydration counts as populated, so within TTL this is a
+ * no-op. Fetches run sequentially (rate-limit politeness, mirroring
+ * populateStoresFromFio) and the function is fire-and-forget safe: a
+ * failed endpoint is logged and skipped, never thrown, and one endpoint
+ * failing doesn't block the other.
+ */
+export async function ensureReferenceData(): Promise<void> {
+  if (!useMaterialsStore.getState().fetched) {
+    const result = await fetchAllMaterials();
+    if (result.ok) {
+      useMaterialsStore.getState().setAll(transformAllMaterials(result.data));
+      useMaterialsStore.getState().setFetched('fio');
+    } else {
+      warn('FIO materials reference fetch failed:', result.error.message);
+    }
+  }
+
+  if (!useCxStore.getState().fetched) {
+    const result = await fetchExchangeAll();
+    if (result.ok) {
+      useCxStore.getState().setAll(transformAllExchange(result.data));
+      useCxStore.getState().setFetched('fio');
+    } else {
+      warn('FIO exchange reference fetch failed:', result.error.message);
+    }
+  }
+}

--- a/lib/fio/transforms.ts
+++ b/lib/fio/transforms.ts
@@ -18,7 +18,10 @@ import type {
   FioStorageItem,
   FioSite,
   FioSiteBuilding,
+  FioMaterial,
+  FioExchangeEntry,
 } from './types';
+import type { MaterialInfo, CxEntry } from '../../stores/reference';
 import { warn } from '../debug/logger';
 
 /**
@@ -372,4 +375,60 @@ export function transformSite(fioSite: FioSite): PrunApi.Site {
 
 export function transformAllSites(fioSites: unknown): PrunApi.Site[] {
   return mapFioArray('sites', fioSites, transformSite);
+}
+
+// ============================================================================
+// Public Reference Data Transforms
+// ============================================================================
+
+/**
+ * Transforms a FIO material record to the reference store shape.
+ * Flat records can't throw on field access, so the identity fields are
+ * checked explicitly — that is what lets mapFioArray skip a malformed
+ * record instead of storing a half-empty one.
+ */
+export function transformMaterial(fio: FioMaterial): MaterialInfo {
+  if (typeof fio.Ticker !== 'string' || typeof fio.Name !== 'string') {
+    throw new Error('material record missing Ticker/Name');
+  }
+  return {
+    ticker: fio.Ticker,
+    name: fio.Name,
+    category: fio.CategoryName,
+    weight: fio.Weight,
+    volume: fio.Volume,
+  };
+}
+
+export function transformAllMaterials(data: unknown): MaterialInfo[] {
+  return mapFioArray('materials', data, transformMaterial);
+}
+
+/**
+ * Transforms a FIO exchange entry to the reference store shape.
+ * Ticker and exchange code form the store key, so both are validated;
+ * bid/ask/MM fields stay nullable (null on illiquid pairs).
+ */
+export function transformExchangeEntry(fio: FioExchangeEntry): CxEntry {
+  if (
+    typeof fio.MaterialTicker !== 'string' ||
+    typeof fio.ExchangeCode !== 'string'
+  ) {
+    throw new Error('exchange record missing MaterialTicker/ExchangeCode');
+  }
+  return {
+    ticker: fio.MaterialTicker,
+    exchangeCode: fio.ExchangeCode,
+    bid: fio.Bid,
+    ask: fio.Ask,
+    priceAverage: fio.PriceAverage,
+    supply: fio.Supply,
+    demand: fio.Demand,
+    mmBuy: fio.MMBuy,
+    mmSell: fio.MMSell,
+  };
+}
+
+export function transformAllExchange(data: unknown): CxEntry[] {
+  return mapFioArray('exchange', data, transformExchangeEntry);
 }

--- a/lib/fio/types.ts
+++ b/lib/fio/types.ts
@@ -145,6 +145,39 @@ export interface FioSite {
 }
 
 // ============================================================================
+// Public Reference Data Endpoint Types (no auth)
+// ============================================================================
+
+/** GET /material/allmaterials */
+export interface FioMaterial {
+  MaterialId: string;
+  CategoryName: string;
+  CategoryId: string;
+  Name: string;
+  Ticker: string;
+  Weight: number;
+  Volume: number;
+}
+
+/**
+ * GET /exchange/all — simplified market data, one entry per
+ * material × exchange. Bid/ask/MM fields are null on illiquid pairs.
+ */
+export interface FioExchangeEntry {
+  MaterialTicker: string;
+  ExchangeCode: string;
+  MMBuy: number | null;
+  MMSell: number | null;
+  PriceAverage: number;
+  AskCount: number | null;
+  Ask: number | null;
+  Supply: number;
+  BidCount: number | null;
+  Bid: number | null;
+  Demand: number;
+}
+
+// ============================================================================
 // Error Types
 // ============================================================================
 

--- a/stores/__tests__/reference.test.ts
+++ b/stores/__tests__/reference.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  useMaterialsStore,
+  useCxStore,
+  getMaterialName,
+  getCxEntry,
+} from '../reference';
+
+describe('reference stores', () => {
+  beforeEach(() => {
+    useMaterialsStore.getState().clear();
+    useCxStore.getState().clear();
+  });
+
+  describe('getMaterialName', () => {
+    beforeEach(() => {
+      useMaterialsStore.getState().setAll([
+        { ticker: 'RAT', name: 'Rations', category: 'consumables (basic)', weight: 0.21, volume: 0.1 },
+        { ticker: 'DW', name: 'Drinking Water', category: 'consumables (basic)', weight: 0.1, volume: 0.1 },
+      ]);
+    });
+
+    it('returns the name for a known ticker', () => {
+      expect(getMaterialName('RAT')).toBe('Rations');
+    });
+
+    it('is case-insensitive on the ticker', () => {
+      expect(getMaterialName('dw')).toBe('Drinking Water');
+    });
+
+    it('returns undefined for an unknown ticker', () => {
+      expect(getMaterialName('XYZ')).toBeUndefined();
+    });
+
+    it('returns undefined when the store is empty', () => {
+      useMaterialsStore.getState().clear();
+      expect(getMaterialName('RAT')).toBeUndefined();
+    });
+  });
+
+  describe('getCxEntry', () => {
+    beforeEach(() => {
+      useCxStore.getState().setAll([
+        {
+          ticker: 'RAT',
+          exchangeCode: 'AI1',
+          bid: 101,
+          ask: 110,
+          priceAverage: 105.5,
+          supply: 5000,
+          demand: 3200,
+          mmBuy: null,
+          mmSell: null,
+        },
+        {
+          ticker: 'RAT',
+          exchangeCode: 'CI1',
+          bid: 95,
+          ask: 99,
+          priceAverage: 97,
+          supply: 800,
+          demand: 1200,
+          mmBuy: null,
+          mmSell: null,
+        },
+      ]);
+    });
+
+    it('looks up by the composite ticker + exchange key', () => {
+      expect(getCxEntry('RAT', 'AI1')?.priceAverage).toBe(105.5);
+      expect(getCxEntry('RAT', 'CI1')?.priceAverage).toBe(97);
+    });
+
+    it('is case-insensitive on both parts', () => {
+      expect(getCxEntry('rat', 'ai1')?.ask).toBe(110);
+    });
+
+    it('returns undefined for an unknown pair', () => {
+      expect(getCxEntry('RAT', 'NC1')).toBeUndefined();
+    });
+  });
+});

--- a/stores/reference.ts
+++ b/stores/reference.ts
@@ -1,0 +1,73 @@
+/**
+ * Public FIO reference data stores: materials database and CX prices.
+ *
+ * Reference data is static/slow-changing, so unlike the game-state entity
+ * stores these are deliberately NOT cleared on CLIENT_CONNECTION_OPENED
+ * reconnects (a reconnect doesn't invalidate what a material is called) —
+ * they are simply never listed in clearAllEntityStores. The persist TTLs
+ * control freshness instead, and the createEntityStore version check
+ * refetches automatically after an extension update.
+ */
+
+import { createEntityStore } from './create-entity-store';
+
+export interface MaterialInfo {
+  ticker: string;
+  name: string;
+  /** FIO CategoryName, raw — the static MATERIAL_CATEGORIES map stays the
+   *  primary source for category display/colour lookups. */
+  category: string;
+  weight: number;
+  volume: number;
+}
+
+export interface CxEntry {
+  ticker: string;
+  exchangeCode: string;
+  bid: number | null;
+  ask: number | null;
+  priceAverage: number;
+  supply: number;
+  demand: number;
+  mmBuy: number | null;
+  mmSell: number | null;
+}
+
+/** Materials are effectively static — a week-old name is still correct. */
+export const MATERIALS_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+/** FIO caches /exchange/all server-side for ~15 minutes; an hour keeps us
+ *  to at most one fetch per page load without hammering the endpoint. */
+export const CX_CACHE_TTL_MS = 60 * 60 * 1000;
+
+export const useMaterialsStore = createEntityStore<MaterialInfo>(
+  'materials',
+  (m) => m.ticker,
+  { key: 'apxm_cache_materials', ttlMs: MATERIALS_CACHE_TTL_MS }
+);
+
+export const useCxStore = createEntityStore<CxEntry>(
+  'cx',
+  (e) => `${e.ticker}.${e.exchangeCode}`,
+  { key: 'apxm_cache_cx', ttlMs: CX_CACHE_TTL_MS }
+);
+
+/**
+ * Full display name for a material ticker, if the materials database has
+ * been fetched. Callers must degrade to the ticker when undefined.
+ */
+export function getMaterialName(ticker: string): string | undefined {
+  return useMaterialsStore.getState().getById(ticker.toUpperCase())?.name;
+}
+
+/**
+ * Market entry for a material on a specific exchange (e.g. 'RAT', 'AI1').
+ */
+export function getCxEntry(
+  ticker: string,
+  exchangeCode: string
+): CxEntry | undefined {
+  return useCxStore
+    .getState()
+    .getById(`${ticker.toUpperCase()}.${exchangeCode.toUpperCase()}`);
+}


### PR DESCRIPTION
Partial implementation of #2, deliberately scoped to the two datasets with actual consumers. **Buildings and recipes are deferred** until something uses them — leaving #2 open for that remainder.

**Data layer:**
- Anonymous `fioFetchPublic` (no Authorization header) for `GET /material/allmaterials` and `GET /exchange/all`. `host_permissions` already covers rest.fnar.net — no manifest change.
- Two reference stores reusing `createEntityStore` persistence: materials TTL **7 days** (effectively static), CX **1 hour** (FIO server-caches ~15 min). The existing build-version check on the cache gives refetch-on-extension-update for free.
- Reference stores are deliberately **not** cleared on `CLIENT_CONNECTION_OPENED` — that rule exists because game state goes stale on reconnect; a reconnect doesn't invalidate what a material is called. TTLs control freshness instead. ("Clear Cached Data" in Settings does clear them; they refetch next load.)
- `ensureReferenceData()` runs fire-and-forget at startup, skips stores already populated (a fresh cache rehydration counts), fetches sequentially for rate-limit politeness, and logs-and-continues on failure so one endpoint can't block the other.
- Transforms route through the `mapFioArray` hostile-input boundary, with explicit identity-field validation — flat records can't throw on field access, so without it the skip path could never fire.

**UI in this PR:** burn rows are now tap-expandable — full material name plus the in/out/workforce daily-rate breakdown (first UI use of those `BurnRate` fields; the dead `detailed` prop is replaced). Names fall back from WS/FIO payloads to the materials database, fixing ticker-only display where FIO auth isn't configured. No staleness badge on names: the staleness rule guards game-state displays, and reference data isn't game state.

**CX prices have no UI yet by design** — `getCxEntry(ticker, exchangeCode)` is the tested public contract; inventory valuation is the follow-up that consumes it.

**Note for device pass:** expandable rows keep the dense row height (~26px tall, full-width tap target) rather than growing to the 44pt minimum — density vs touch-target tension; easy to bump row padding if taps feel fiddly on device.

**Tests:** 21 new (384 total) — transform boundary cases, public-client contract (no auth header, error mapping), coordinator skip/retry/partial-failure, lookup helpers. `tsc --noEmit` clean; both build targets verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)