### PR TITLE
feat(theme): DryDock material theme — neon-sign tiles

### DIFF
--- a/components/shared/MaterialTile.tsx
+++ b/components/shared/MaterialTile.tsx
@@ -35,7 +35,12 @@ export function MaterialTile({ ticker, category, size = 'md' }: MaterialTileProp
       style={{
         backgroundColor: colors.bg,
         color: colors.text,
-        textShadow: '1px 1px 1px rgba(0, 0, 0, 0.7)',
+        // Border is always present so themes with and without one render
+        // at identical size; bordered (neon) tiles drop the text shadow —
+        // their look is crisp bright glyphs on a dark fill.
+        border: '1px solid',
+        borderColor: colors.border ?? 'transparent',
+        textShadow: colors.border ? 'none' : '1px 1px 1px rgba(0, 0, 0, 0.7)',
       }}
     >
       {ticker}

--- a/components/views/SettingsView.tsx
+++ b/components/views/SettingsView.tsx
@@ -10,6 +10,12 @@ import { testConnection, populateStoresFromFio, type FioProgressStep } from '../
 import { clearAllCache } from '../../stores/cache';
 import { themePresets } from '../../lib/theme';
 
+const materialThemeOptions: { id: MaterialTheme; label: string }[] = [
+  { id: 'rprun', label: 'rPrUn' },
+  { id: 'prun', label: 'PrUn' },
+  { id: 'drydock', label: 'DryDock' },
+];
+
 /** 24-bit hex number → CSS hex string, for inline preset-preview swatches. */
 function toCssHex(value: number): string {
   return `#${value.toString(16).padStart(6, '0')}`;
@@ -503,26 +509,19 @@ export function SettingsView() {
 
         <div className="space-y-3">
           <div className="flex gap-2">
-            <button
-              onClick={() => setMaterialTheme('rprun')}
-              className={`flex-1 min-h-touch px-4 py-2 text-sm rounded font-semibold ${
-                materialTheme === 'rprun'
-                  ? 'bg-prun-yellow text-apxm-bg'
-                  : 'border border-apxm-accent text-apxm-muted'
-              }`}
-            >
-              rPrUn
-            </button>
-            <button
-              onClick={() => setMaterialTheme('prun')}
-              className={`flex-1 min-h-touch px-4 py-2 text-sm rounded font-semibold ${
-                materialTheme === 'prun'
-                  ? 'bg-prun-yellow text-apxm-bg'
-                  : 'border border-apxm-accent text-apxm-muted'
-              }`}
-            >
-              PrUn
-            </button>
+            {materialThemeOptions.map((option) => (
+              <button
+                key={option.id}
+                onClick={() => setMaterialTheme(option.id)}
+                className={`flex-1 min-h-touch px-4 py-2 text-sm rounded font-semibold ${
+                  materialTheme === option.id
+                    ? 'bg-prun-yellow text-apxm-bg'
+                    : 'border border-apxm-accent text-apxm-muted'
+                }`}
+              >
+                {option.label}
+              </button>
+            ))}
           </div>
 
           {/* Preview tiles */}

--- a/lib/__tests__/material-colors.test.ts
+++ b/lib/__tests__/material-colors.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { normalizeCategory, getCategoryColors, type MaterialTheme } from '../material-colors';
+import { MATERIAL_CATEGORIES } from '../material-categories';
 
 describe('material-colors', () => {
   describe('normalizeCategory', () => {
@@ -85,6 +86,47 @@ describe('material-colors', () => {
         const colors = getCategoryColors('unknown-category', theme);
         expect(colors.bg).toBe('#2a2a3c');
         expect(colors.text).toBe('#808080');
+      });
+    });
+
+    describe('drydock theme', () => {
+      const theme: MaterialTheme = 'drydock';
+
+      it('returns the DryDock palette value for a native category (fuels)', () => {
+        const colors = getCategoryColors('fuels', theme);
+        expect(colors).toEqual({ bg: '#1a1a1a', text: '#a0ff60', border: '#a0ff60' });
+      });
+
+      it('renders a derived category in the same neon style: dark fill, text matching border', () => {
+        const colors = getCategoryColors('agricultural-products', theme);
+        expect(colors.bg).toBe('#1a1a1a');
+        expect(colors.border).toBeDefined();
+        expect(colors.text).toBe(colors.border);
+      });
+
+      it('covers every category a material can resolve to with the full neon contract', () => {
+        // MaterialTile looks up via MATERIAL_CATEGORIES, so its unique slugs
+        // are the complete set of categories the tile can ever request.
+        const slugs = new Set(Object.values(MATERIAL_CATEGORIES));
+        for (const slug of slugs) {
+          const colors = getCategoryColors(slug, theme);
+          expect(colors.bg, slug).toBe('#1a1a1a');
+          expect(colors.border, slug).toBeDefined();
+          expect(colors.text, slug).toBe(colors.border);
+        }
+      });
+
+      it('returns a neon-styled default for unknown categories', () => {
+        const colors = getCategoryColors('unknown-category', theme);
+        expect(colors).toEqual({ bg: '#1a1a1a', text: '#808080', border: '#808080' });
+      });
+    });
+
+    describe('border back-compat contract', () => {
+      it('prun and rprun themes never set a border — existing tiles rely on borderless rendering', () => {
+        expect(getCategoryColors('metals', 'prun').border).toBeUndefined();
+        expect(getCategoryColors('fuels', 'rprun').border).toBeUndefined();
+        expect(getCategoryColors('unknown-category', 'prun').border).toBeUndefined();
       });
     });
   });

--- a/lib/material-colors.ts
+++ b/lib/material-colors.ts
@@ -2,18 +2,23 @@
  * Material Category Color Palettes
  *
  * Color schemes for material tiles based on category.
- * Two themes:
+ * Three themes:
  * - prun: Stock game colors (from PrUn JS bundle)
  * - rprun: rPrUn extension colors (overrides 7 categories)
+ * - drydock: DryDock's neon-sign style — dark fill, category colour as
+ *   both border and text (ported from drydock src/theme/tokens.css)
  *
  * Source: refined-prun/src/infrastructure/prun-ui/item-tracker.ts
  */
 
-export type MaterialTheme = 'rprun' | 'prun';
+export type MaterialTheme = 'rprun' | 'prun' | 'drydock';
 
 export interface CategoryColors {
   bg: string;
   text: string;
+  /** Tile border colour. Only the drydock theme sets it — tiles draw a
+   *  border iff the theme provides one. */
+  border?: string;
 }
 
 /**
@@ -81,7 +86,64 @@ const RPRUN_COLORS: Record<string, CategoryColors> = {
   'ship-shields': { bg: '#bf740a', text: '#dbdb79' },           // dark orange (was pastel)
 };
 
+const DRYDOCK_BG = '#1a1a1a';
+
+/** DryDock neon tile: bright category colour as both text and border over
+ *  the shared dark fill. No glow/shadow — the "neon" read comes entirely
+ *  from the bright-on-dark contrast. */
+function neon(color: string): CategoryColors {
+  return { bg: DRYDOCK_BG, text: color, border: color };
+}
+
+/**
+ * DryDock theme. The 14 categories DryDock itself defines use its palette
+ * verbatim; the remaining 21 reuse the prun theme's text colours (already
+ * the bright variant of each category) so the whole set reads as one style.
+ */
+const DRYDOCK_COLORS: Record<string, CategoryColors> = {
+  // DryDock-native palette (drydock src/theme/tokens.css)
+  'alloys': neon('#ffaa44'),
+  'chemicals': neon('#ff7eb3'),
+  'construction-materials': neon('#5eaaff'),
+  'electronic-systems': neon('#9955dd'),
+  'elements': neon('#c9a06a'),
+  'fuels': neon('#a0ff60'),
+  'metals': neon('#b0b0b0'),
+  'minerals': neon('#e8c9a0'),
+  'plastics': neon('#ff6be0'),
+  'ship-engines': neon('#ff5522'),
+  'ship-kits': neon('#ffaa22'),
+  'ship-parts': neon('#ffcc33'),
+  'ship-shields': neon('#ffd34d'),
+  'unit-prefabs': neon('#5a8c8c'),
+  // Derived from the prun theme's text colours
+  'agricultural-products': neon('#e54a4a'),
+  'construction-parts': neon('#78b0e0'),
+  'construction-prefabs': neon('#4868e0'),
+  'consumable-bundles': neon('#c04058'),
+  'consumables-basic': neon('#f08888'),
+  'consumables-luxury': neon('#f86080'),
+  'drones': neon('#ff8858'),
+  'electronic-devices': neon('#b868ff'),
+  'electronic-parts': neon('#c0a0ff'),
+  'electronic-pieces': neon('#d8c8ff'),
+  'energy-systems': neon('#60c090'),
+  'gases': neon('#48ffff'),
+  'infrastructure': neon('#5050b0'),
+  'liquids': neon('#e8ffff'),
+  'medical-equipment': neon('#c0ffc0'),
+  'ores': neon('#b0b8c8'),
+  'software-components': neon('#e8e090'),
+  'software-systems': neon('#c8b040'),
+  'software-tools': neon('#ffd058'),
+  'textiles': neon('#c0d070'),
+  'utility': neon('#f0e8e0'),
+};
+
 const DEFAULT_COLORS: CategoryColors = { bg: '#2a2a3c', text: '#808080' };
+
+// An unknown category should still read as the active theme's style
+const DRYDOCK_DEFAULT: CategoryColors = neon('#808080');
 
 /**
  * Normalizes a category name to slug format for lookup.
@@ -96,11 +158,20 @@ export function normalizeCategory(category: string | null | undefined): string {
     .replace(/\s+/g, '-');
 }
 
+const PALETTES: Record<
+  MaterialTheme,
+  { colors: Record<string, CategoryColors>; fallback: CategoryColors }
+> = {
+  prun: { colors: PRUN_COLORS, fallback: DEFAULT_COLORS },
+  rprun: { colors: RPRUN_COLORS, fallback: DEFAULT_COLORS },
+  drydock: { colors: DRYDOCK_COLORS, fallback: DRYDOCK_DEFAULT },
+};
+
 /**
- * Returns the background and text colors for a material category.
+ * Returns the tile colors for a material category under the given theme.
  */
 export function getCategoryColors(category: string, theme: MaterialTheme): CategoryColors {
   const slug = normalizeCategory(category);
-  const palette = theme === 'rprun' ? RPRUN_COLORS : PRUN_COLORS;
-  return palette[slug] ?? DEFAULT_COLORS;
+  const palette = PALETTES[theme];
+  return palette.colors[slug] ?? palette.fallback;
 }

--- a/stores/settings.ts
+++ b/stores/settings.ts
@@ -2,6 +2,11 @@ import { create } from 'zustand';
 import { persist, createJSONStorage, type StateStorage } from 'zustand/middleware';
 import { browser } from 'wxt/browser';
 import { DEFAULT_THEME_ID, type ApxmThemeId } from '../lib/theme';
+import type { MaterialTheme } from '../lib/material-colors';
+
+// Re-exported so settings consumers don't need a second import; the palette
+// module owns the definition (it changes when palettes are added).
+export type { MaterialTheme } from '../lib/material-colors';
 
 export interface BurnThresholds {
   critical: number; // days — default 3
@@ -21,8 +26,6 @@ export interface FioConfig {
   username: string | null;
   lastFetch: number | null;
 }
-
-export type MaterialTheme = 'rprun' | 'prun';
 
 interface SettingsState {
   burnThresholds: BurnThresholds;


### PR DESCRIPTION
Closes #34.

Adds **DryDock** as the third material theme, ported from DryDock's `.ticker-badge` style: shared dark fill (`#1a1a1a`) with the category colour as both 1px border and text. No box-shadow/glow — verified against DryDock's CSS, the neon read comes entirely from bright-on-dark contrast.

**Palette:** the 14 categories DryDock defines use its `tokens.css` values verbatim (all map 1:1 onto APXM slugs). The remaining 21 APXM categories reuse the prun theme's text colours — already each category's bright variant — over the same dark fill, so the whole 35-category set reads as one coherent style. Unknown categories get a neon-styled grey default rather than the flat default, so they don't break the theme.

**Tile rendering:** `CategoryColors` gains an optional `border`; tiles draw a border iff the theme provides one. The 1px border is always rendered (transparent for prun/rprun) so switching themes can't shift tile size, and bordered tiles drop the text shadow.

**Type consolidation:** `MaterialTheme` was defined independently in both `material-colors.ts` and `settings.ts` — widening one wouldn't widen the other. The palette module now owns it; settings re-exports, so existing imports keep working. The new enum value is additive on a flat persisted key — no migration.

**Settings:** picker generalised from two hardcoded buttons to a mapped three-option row; the existing 8-tile preview already exercises both native (FF/PE/FE/MCG) and derived (GRN/RAT/H2O/SAR) halves of the palette.

**Tests:** 5 new (368 total) — native value, derived-style contract (dark fill, text === border), full coverage over every slug `MATERIAL_CATEGORIES` can resolve, neon default, and the back-compat contract that prun/rprun stay borderless. `tsc --noEmit` clean; both build targets verified.

**Device pass:** check tile sizing didn't shift across themes and the DryDock preview against the screenshot in #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)