### PR TITLE
fix(currency): key faction→currency map by countryId GUID (#57)

### DIFF
--- a/lib/__tests__/currency.test.ts
+++ b/lib/__tests__/currency.test.ts
@@ -7,14 +7,18 @@ function balance(currency: string, amount = 1000): PrunApi.CurrencyAmount {
 }
 
 describe('primaryCurrencyFor', () => {
-  it('maps known faction countryIds to their currency', () => {
-    expect(primaryCurrencyFor('AI')).toBe('AIC');
-    expect(primaryCurrencyFor('CI')).toBe('CIS');
-    expect(primaryCurrencyFor('IC')).toBe('ICA');
-    expect(primaryCurrencyFor('NC')).toBe('NCC');
+  // GUID keys from FIO GET /global/countries (CountryRegistryCountryId).
+  // COMPANY_DATA delivers these GUIDs as countryId, not the 2-letter code.
+  it('maps known faction countryId GUIDs to their currency', () => {
+    expect(primaryCurrencyFor('18419e6fd11b5af8bf0d0a996ad1a622')).toBe('AIC');
+    expect(primaryCurrencyFor('981c095a8ddc128232a149e109448ed8')).toBe('CIS');
+    expect(primaryCurrencyFor('4a2fe1ae3e1ca07dcfebbdf25c4b8d6a')).toBe('ICA');
+    expect(primaryCurrencyFor('a6d40e12e79f0b2d644bfe0880fd219d')).toBe('NCC');
   });
 
   it('returns null for unknown countryIds', () => {
+    // 2-letter codes are the pre-#57 bug: they must NOT resolve.
+    expect(primaryCurrencyFor('AI')).toBeNull();
     expect(primaryCurrencyFor('XX')).toBeNull();
     expect(primaryCurrencyFor('')).toBeNull();
   });

--- a/lib/currency.ts
+++ b/lib/currency.ts
@@ -2,15 +2,23 @@ import type { PrunApi } from '../types/prun-api';
 
 /**
  * Faction countryId → primary currency.
- * Lifted from the archived desktop bridge (desktop-view-archive-20260606).
- * The countryId keys are unverified against live WS data (issue #26) — an
- * unmapped countryId returns null, which degrades to alphabetical ordering.
+ *
+ * COMPANY_DATA's `countryId` is a GUID (e.g. AI = 18419e6f…), NOT the 2-letter
+ * faction code — and no countryCode field travels alongside it, so the GUID is
+ * the only faction identifier available (issue #57). The earlier 2-letter keys
+ * never matched, leaving every company on the alphabetical fallback; it only
+ * looked correct for AI because AIC sorts first alphabetically anyway.
+ *
+ * Keys verified against FIO `GET /global/countries` (the country registry —
+ * CountryRegistryCountryId → CurrencyCode). Faction IDs are immutable game
+ * constants, so this stays a static map. An unmapped countryId returns null,
+ * which degrades to alphabetical ordering.
  */
 const COUNTRY_CURRENCY: Record<string, string> = {
-  AI: 'AIC',
-  CI: 'CIS',
-  IC: 'ICA',
-  NC: 'NCC',
+  '18419e6fd11b5af8bf0d0a996ad1a622': 'AIC', // Antares Initiative (AI)
+  '981c095a8ddc128232a149e109448ed8': 'CIS', // Castillo-Ito Mercantile (CI)
+  '4a2fe1ae3e1ca07dcfebbdf25c4b8d6a': 'ICA', // Insitor Cooperative (IC)
+  'a6d40e12e79f0b2d644bfe0880fd219d': 'NCC', // NEO Charter Exploration (NC)
 };
 
 export function primaryCurrencyFor(countryId: string): string | null {


### PR DESCRIPTION
COMPANY_DATA's `countryId` is a GUID, not the 2-letter faction code, and carries no `countryCode` field. `COUNTRY_CURRENCY` was keyed by 2-letter codes, so the key never matched — `primaryCurrencyFor` always returned null and the Status-page currency list fell through to alphabetical. Invisible for AI companies (AIC sorts first anyway); an IC company saw AIC instead of ICA.

Re-keyed the map by faction GUID, verified against FIO `GET /global/countries` (`CountryRegistryCountryId` → `CurrencyCode`). The data flow was already correct — only the map keys were wrong.

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)