### PR TITLE
v1.0.1 — login-screen dormancy + DryDock tint fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # APXM Changelog
 
+## 1.0.1 (2026-07-06)
+
+Bugfix release for the first public wave.
+
+### Fixed
+
+- **Logged-out first use** (#64) — APXM now stays out of the way while APEX shows its login screen, instead of covering the login form and then showing a misleading "isn't receiving game data" error. Log in as normal and APXM appears once your session starts
+- **DryDock material tints** (#61) — the DryDock theme's agricultural products, basic/luxury consumables, and liquids tiles now use the rPrun colours (agricultural products reads green, not stock red)
+
+### Notes
+
+- Tests: 450
+
 ## 1.0.0 — Retro Terminal (2026-06-18)
 
 The 1.0 release: a full visual redesign and a reworked, customisable Status tab.

--- a/components/App.tsx
+++ b/components/App.tsx
@@ -9,6 +9,9 @@ export function App() {
   const apexVisible = useGameState((s) => s.apexVisible);
   const availability = useAvailabilityStatus();
   const interceptorConflict = useConnectionStore((s) => s.interceptorConflict);
+  // APEX is showing its login screen — APXM stays dormant (host collapsed,
+  // nothing rendered) so the user can reach the form (#64).
+  const loginRequired = availability === 'login';
 
   // Toggle shadow host between opaque fullscreen (APXM) and collapsed transparent
   // (APEX). The :host(.apex-visible) CSS rule in styles.css handles the visual
@@ -17,8 +20,8 @@ export function App() {
   useEffect(() => {
     const host = document.querySelector('apxm-overlay') as HTMLElement | null;
     if (host) {
-      host.classList.toggle('apex-visible', apexVisible);
-      if (apexVisible) {
+      host.classList.toggle('apex-visible', apexVisible || loginRequired);
+      if (apexVisible && !loginRequired) {
         host.style.opacity = '0.3';
         host.style.pointerEvents = 'none';
       } else {
@@ -26,7 +29,7 @@ export function App() {
         host.style.pointerEvents = '';
       }
     }
-  }, [apexVisible]);
+  }, [apexVisible, loginRequired]);
 
   // Manage #container visibility and offset when toggling APEX.
   // When APEX visible: ensure display, offset below FloatingReturn bar.
@@ -68,6 +71,10 @@ export function App() {
     });
     return () => observer.disconnect();
   }, [apexVisible]);
+
+  if (availability === 'login') {
+    return null;
+  }
 
   if (availability !== 'ok') {
     return (

--- a/hooks/__tests__/useAvailabilityStatus.test.ts
+++ b/hooks/__tests__/useAvailabilityStatus.test.ts
@@ -4,6 +4,7 @@ import { deriveAvailability } from '../useAvailabilityStatus';
 describe('deriveAvailability', () => {
   const base = {
     messageCount: 0,
+    loginScreen: false,
     apexErrorBanner: false,
     elapsedMs: 0,
     interceptorConflict: false,
@@ -39,6 +40,21 @@ describe('deriveAvailability', () => {
       deriveAvailability({ ...base, interceptorConflict: true, elapsedMs: 5_000 })
     ).toBe('starved');
     expect(deriveAvailability({ ...base, elapsedMs: 5_000 })).toBe('ok');
+  });
+
+  it('reports login when the APEX login screen is showing and no data (#64)', () => {
+    expect(deriveAvailability({ ...base, loginScreen: true })).toBe('login');
+    // The login screen wins over both error signals — with no session the
+    // user needs the form, not an APXM overlay.
+    expect(
+      deriveAvailability({ ...base, loginScreen: true, apexErrorBanner: true })
+    ).toBe('login');
+    expect(
+      deriveAvailability({ ...base, loginScreen: true, elapsedMs: 30_000 })
+    ).toBe('login');
+    // Flowing data still wins — a password field elsewhere must not blank a
+    // working session.
+    expect(deriveAvailability({ ...base, loginScreen: true, messageCount: 1 })).toBe('ok');
   });
 
   it('prefers the genuine maintenance signal over a starvation timeout', () => {

--- a/hooks/useAvailabilityStatus.ts
+++ b/hooks/useAvailabilityStatus.ts
@@ -4,12 +4,14 @@ import { useConnectionStore } from '../stores/connection';
 /**
  * Why the overlay is (or isn't) showing:
  * - 'ok'          — data is flowing, or we're still within the startup grace
+ * - 'login'       — APEX is showing its login screen; APXM must stay dormant
+ *                   so the user can actually log in
  * - 'maintenance' — APEX's own error banner confirms the server is unavailable
  * - 'starved'     — no data is arriving and we don't know the server is down;
  *                   the likely cause is a competing extension intercepting the
  *                   connection (or a broken injection), not maintenance
  */
-export type AvailabilityReason = 'ok' | 'maintenance' | 'starved';
+export type AvailabilityReason = 'ok' | 'login' | 'maintenance' | 'starved';
 
 const TIMEOUT_MS = 20_000;
 /** Shorter grace once a competing interceptor is confirmed — no point making
@@ -30,16 +32,38 @@ function detectApexErrorBanner(): boolean {
 }
 
 /**
+ * Check for APEX's login screen. APEX renders a dedicated login-required
+ * frame when there is no session; its class names carry a build hash, so
+ * match on the stable BEM prefix. A password input is the fallback signal —
+ * the game UI itself has none, and APXM's own inputs live in the shadow
+ * root, which document-level queries can't reach.
+ */
+function detectLoginScreen(): boolean {
+  try {
+    return (
+      document.querySelector('[class*="Frame__loginRequired"]') !== null ||
+      document.querySelector('input[type="password"]') !== null
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Pure availability classification (extracted for testing). The starvation
- * timeout shortens when a competing interceptor is confirmed.
+ * timeout shortens when a competing interceptor is confirmed. The login
+ * screen wins over everything except flowing data — with no session there
+ * is nothing APXM can usefully say, and the user needs the form.
  */
 export function deriveAvailability(params: {
   messageCount: number;
+  loginScreen: boolean;
   apexErrorBanner: boolean;
   elapsedMs: number;
   interceptorConflict: boolean;
 }): AvailabilityReason {
   if (params.messageCount > 0) return 'ok';
+  if (params.loginScreen) return 'login';
   if (params.apexErrorBanner) return 'maintenance';
   const timeoutMs = params.interceptorConflict ? CONFLICT_GRACE_MS : TIMEOUT_MS;
   return params.elapsedMs >= timeoutMs ? 'starved' : 'ok';
@@ -62,16 +86,22 @@ export function useAvailabilityStatus(): AvailabilityReason {
       return;
     }
 
-    const startTime = Date.now();
+    let startTime = Date.now();
     const intervalId = setInterval(() => {
+      const loginScreen = detectLoginScreen();
+      // Time on the login screen doesn't count toward starvation — the
+      // grace window restarts once the user logs in.
+      if (loginScreen) startTime = Date.now();
       const next = deriveAvailability({
         messageCount: useConnectionStore.getState().messageCount,
+        loginScreen,
         apexErrorBanner: detectApexErrorBanner(),
         elapsedMs: Date.now() - startTime,
         interceptorConflict,
       });
-      if (next !== 'ok') {
-        setReason(next);
+      setReason(next);
+      // 'login' is not terminal — keep polling so APXM wakes after login.
+      if (next === 'maintenance' || next === 'starved') {
         clearInterval(intervalId);
       }
     }, POLL_INTERVAL_MS);

--- a/lib/__tests__/material-colors.test.ts
+++ b/lib/__tests__/material-colors.test.ts
@@ -104,6 +104,23 @@ describe('material-colors', () => {
         expect(colors.text).toBe(colors.border);
       });
 
+      it('derives non-native tints from rprun, not prun (#61)', () => {
+        // The four rprun overrides that are not DryDock-native must carry the
+        // rprun text colour — agricultural products reads green, not PrUn red.
+        expect(getCategoryColors('agricultural-products', theme).text).toBe(
+          getCategoryColors('agricultural-products', 'rprun').text
+        );
+        expect(getCategoryColors('consumables-basic', theme).text).toBe(
+          getCategoryColors('consumables-basic', 'rprun').text
+        );
+        expect(getCategoryColors('consumables-luxury', theme).text).toBe(
+          getCategoryColors('consumables-luxury', 'rprun').text
+        );
+        expect(getCategoryColors('liquids', theme).text).toBe(
+          getCategoryColors('liquids', 'rprun').text
+        );
+      });
+
       it('covers every category a material can resolve to with the full neon contract', () => {
         // MaterialTile looks up via MATERIAL_CATEGORIES, so its unique slugs
         // are the complete set of categories the tile can ever request.

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,1 +1,1 @@
-export const BUILD_VERSION = 'v1.0.0';
+export const BUILD_VERSION = 'v1.0.1';

--- a/lib/material-colors.ts
+++ b/lib/material-colors.ts
@@ -97,7 +97,7 @@ function neon(color: string): CategoryColors {
 
 /**
  * DryDock theme. The 14 categories DryDock itself defines use its palette
- * verbatim; the remaining 21 reuse the prun theme's text colours (already
+ * verbatim; the remaining 21 reuse the rprun theme's text colours (already
  * the bright variant of each category) so the whole set reads as one style.
  */
 const DRYDOCK_COLORS: Record<string, CategoryColors> = {
@@ -116,13 +116,13 @@ const DRYDOCK_COLORS: Record<string, CategoryColors> = {
   'ship-parts': neon('#ffcc33'),
   'ship-shields': neon('#ffd34d'),
   'unit-prefabs': neon('#5a8c8c'),
-  // Derived from the prun theme's text colours
-  'agricultural-products': neon('#e54a4a'),
+  // Derived from the rprun theme's text colours
+  'agricultural-products': neon('#8bb37b'),
   'construction-parts': neon('#78b0e0'),
   'construction-prefabs': neon('#4868e0'),
   'consumable-bundles': neon('#c04058'),
-  'consumables-basic': neon('#f08888'),
-  'consumables-luxury': neon('#f86080'),
+  'consumables-basic': neon('#ff989e'),
+  'consumables-luxury': neon('#db9191'),
   'drones': neon('#ff8858'),
   'electronic-devices': neon('#b868ff'),
   'electronic-parts': neon('#c0a0ff'),
@@ -130,7 +130,7 @@ const DRYDOCK_COLORS: Record<string, CategoryColors> = {
   'energy-systems': neon('#60c090'),
   'gases': neon('#48ffff'),
   'infrastructure': neon('#5050b0'),
-  'liquids': neon('#e8ffff'),
+  'liquids': neon('#f1ffff'),
   'medical-equipment': neon('#c0ffc0'),
   'ores': neon('#b0b8c8'),
   'software-components': neon('#e8e090'),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "apxm",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "APXM — Mobile interface for Prosperous Universe",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Bugfix release for the first public wave, both fixes device-tested.

## Fixes

- **#64 — logged-out first use:** `useAvailabilityStatus` gains a `login` reason. APEX's login screen is detected via `[class*="Frame__loginRequired"]` (from rPrun's parsed APEX stylesheet types) with a light-DOM password-input fallback. While it shows, APXM renders nothing and collapses the shadow host so the form is usable; the 20s starvation clock is suspended and polling continues, so APXM mounts on its own once login completes. Flowing data always wins over the login signal. Closes #64
- **#61 — DryDock tile tints:** the four rPrun overrides that aren't DryDock-native (agricultural products, basic/luxury consumables, liquids) now derive from rPrun text colours instead of PrUn stock. Regression test pins them. Closes #61

## Verification

- 450/450 tests (two new regression tests), typecheck clean
- Chrome + Firefox production builds green
- Device-tested on Bazzite/Firefox: logged-out flow drops to the native login page and APXM mounts after login; interceptor-conflict detection also re-confirmed incidentally (prun-link active); DryDock mats verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)