### PR TITLE
ACT engine foundations: warehouse/exchange/order-book stores (#25/#28)

### DIFF
--- a/stores/__tests__/cxob.test.ts
+++ b/stores/__tests__/cxob.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useCxobStore } from '../cxob';
+import { initMessageHandlers, processMessage } from '../message-handlers';
+import type { ProcessedMessage } from '@prun/link';
+
+function dispatch(messageType: string, payload: unknown): void {
+  const msg: ProcessedMessage = {
+    messageType,
+    payload: { messageType, payload },
+    timestamp: Date.now(),
+    direction: 'inbound',
+    rawSize: 0,
+  };
+  processMessage(msg);
+}
+
+beforeEach(() => {
+  initMessageHandlers();
+  useCxobStore.getState().clear();
+});
+
+describe('cxob store', () => {
+  it('setOrderBook and getByTicker round-trips', () => {
+    useCxobStore.getState().setOrderBook('RAT.CI1', {
+      sellingOrders: [{ amount: 100, limit: { amount: 250 } }],
+      buyingOrders: [],
+    });
+
+    const book = useCxobStore.getState().getByTicker('RAT.CI1');
+    expect(book?.sellingOrders[0].limit.amount).toBe(250);
+    expect(useCxobStore.getState().getByTicker('DW.CI1')).toBeUndefined();
+  });
+
+  it('COMEX_BROKER_DATA (ticker + exchange object) populates the store', () => {
+    dispatch('COMEX_BROKER_DATA', {
+      ticker: 'RAT',
+      exchange: { code: 'CI1' },
+      sellingOrders: [
+        { amount: 200, limit: { amount: 280 } },
+        { amount: null, limit: { amount: 300 } }, // market maker: infinite
+      ],
+      buyingOrders: [{ amount: 100, limit: { amount: 260 } }],
+    });
+
+    const book = useCxobStore.getState().getByTicker('RAT.CI1');
+    expect(book).toBeDefined();
+    expect(book!.sellingOrders).toHaveLength(2);
+    expect(book!.sellingOrders[0].amount).toBe(200);
+    expect(book!.sellingOrders[1].amount).toBeNull();
+    expect(book!.buyingOrders[0].limit.amount).toBe(260);
+  });
+
+  it('COMEX_BROKER_DATA (exchangeCode flat field) populates the store', () => {
+    dispatch('COMEX_BROKER_DATA', {
+      ticker: 'DW',
+      exchangeCode: 'NC1',
+      sellingOrders: [{ amount: 500, limit: { amount: 10 } }],
+      buyingOrders: [],
+    });
+
+    expect(useCxobStore.getState().getByTicker('DW.NC1')?.sellingOrders[0].amount).toBe(500);
+  });
+
+  it('COMEX_BROKER_DATA (material object) populates the store', () => {
+    dispatch('COMEX_BROKER_DATA', {
+      material: { ticker: 'FE' },
+      exchangeCode: 'AI1',
+      sellingOrders: [{ amount: 10, limit: { amount: 100 } }],
+      buyingOrders: [],
+    });
+
+    expect(useCxobStore.getState().getByTicker('FE.AI1')?.sellingOrders[0].limit.amount).toBe(100);
+  });
+
+  it('COMEX_BROKER_DATA with a full CX ticker derives the exchange code', () => {
+    dispatch('COMEX_BROKER_DATA', {
+      ticker: 'H2O.IC1',
+      sellingOrders: [{ amount: 5, limit: { amount: 40 } }],
+      buyingOrders: [],
+    });
+
+    expect(useCxobStore.getState().getByTicker('H2O.IC1')?.sellingOrders[0].amount).toBe(5);
+  });
+
+  it('COMEX_BROKER_DATA drops orders without a numeric limit', () => {
+    dispatch('COMEX_BROKER_DATA', {
+      ticker: 'RAT',
+      exchangeCode: 'CI1',
+      sellingOrders: [{ amount: 10 }, { amount: 20, limit: { amount: 115 } }],
+      buyingOrders: [],
+    });
+
+    const book = useCxobStore.getState().getByTicker('RAT.CI1');
+    expect(book!.sellingOrders).toHaveLength(1);
+    expect(book!.sellingOrders[0].limit.amount).toBe(115);
+  });
+});

--- a/stores/__tests__/cxob.test.ts
+++ b/stores/__tests__/cxob.test.ts
@@ -82,6 +82,37 @@ describe('cxob store', () => {
     expect(useCxobStore.getState().getByTicker('H2O.IC1')?.sellingOrders[0].amount).toBe(5);
   });
 
+  it('COMEX_BROKER_DATA teaches the exchange store the code → station mapping', async () => {
+    const { useExchangeStore } = await import('../exchanges');
+    useExchangeStore.getState().clear();
+
+    dispatch('COMEX_BROKER_DATA', {
+      ticker: 'RAT',
+      exchangeCode: 'CI1',
+      address: {
+        lines: [
+          { type: 'SYSTEM', entity: { naturalId: 'CI' } },
+          { type: 'STATION', entity: { naturalId: 'BEN' } },
+        ],
+      },
+      sellingOrders: [],
+      buyingOrders: [],
+    });
+
+    expect(useExchangeStore.getState().getNaturalIdFromCode('CI1')).toBe('BEN');
+  });
+
+  it('COMEX_BROKER_DATA falls back to itemCount for the order amount', () => {
+    dispatch('COMEX_BROKER_DATA', {
+      ticker: 'RAT',
+      exchangeCode: 'CI1',
+      sellingOrders: [{ itemCount: 42, limit: { amount: 120 } }],
+      buyingOrders: [],
+    });
+
+    expect(useCxobStore.getState().getByTicker('RAT.CI1')?.sellingOrders[0].amount).toBe(42);
+  });
+
   it('COMEX_BROKER_DATA drops orders without a numeric limit', () => {
     dispatch('COMEX_BROKER_DATA', {
       ticker: 'RAT',

--- a/stores/__tests__/message-handlers.test.ts
+++ b/stores/__tests__/message-handlers.test.ts
@@ -25,8 +25,28 @@ import {
 } from '../../__tests__/fixtures/factories';
 import { useSiteSourceStore } from '../site-data-sources';
 import { useCompanyStore } from '../company';
+import { useWarehouseStore } from '../warehouses';
+import { useExchangeStore } from '../exchanges';
+import { useCxobStore } from '../cxob';
 
+// Dispatch using the REAL wire shape: the decoded game message wraps its data
+// as { messageType, payload }, so ProcessedMessage.payload carries that whole
+// envelope and extractPayload must unwrap it. Testing with a flat payload
+// would only exercise the backwards-compat fallback and leave the production
+// unwrapping path unguarded.
 function dispatchMessage(messageType: string, payload: unknown): void {
+  const msg: ProcessedMessage = {
+    messageType,
+    payload: { messageType, payload },
+    timestamp: Date.now(),
+    direction: 'inbound',
+    rawSize: 100,
+  };
+  processMessage(msg);
+}
+
+// Legacy flat shape (no envelope) — extractPayload's documented fallback.
+function dispatchFlatMessage(messageType: string, payload: unknown): void {
   const msg: ProcessedMessage = {
     messageType,
     payload,
@@ -43,6 +63,9 @@ describe('message-handlers', () => {
     useSiteSourceStore.getState().clear();
     useCompanyStore.getState().clear();
     useProductionLoadedStore.getState().clear();
+    useWarehouseStore.getState().clear();
+    useExchangeStore.getState().clear();
+    useCxobStore.getState().clear();
     useConnectionStore.setState({
       connected: false,
       lastMessageTimestamp: null,
@@ -65,14 +88,33 @@ describe('message-handlers', () => {
       dispatchMessage('SITE_SITES', { sites });
       expect(useSitesStore.getState().entities.size).toBe(1);
     });
+
+    it('still handles the legacy flat payload shape (no envelope)', () => {
+      const sites = [createTestSite({ siteId: 'site-flat' })];
+      dispatchFlatMessage('SITE_SITES', { sites });
+      expect(useSitesStore.getState().getById('site-flat')?.siteId).toBe('site-flat');
+    });
   });
 
   describe('CLIENT_CONNECTION_OPENED', () => {
+    // Populate the three ACT-engine stores (not covered by clearAllEntityStores).
+    function populateActStores(): void {
+      useWarehouseStore.getState().setWarehouses([
+        { warehouseId: 'w1', storeId: 's1', systemNaturalId: 'CI', stationNaturalId: 'CI1' },
+      ]);
+      useExchangeStore.getState().setExchange('CI1', 'BEN');
+      useCxobStore.getState().setOrderBook('RAT.CI1', {
+        sellingOrders: [{ amount: 10, limit: { amount: 100 } }],
+        buyingOrders: [],
+      });
+    }
+
     it('preserves entity stores on first connection', () => {
       // Populate stores with cache/FIO data
       useSitesStore.getState().setAll([createTestSite()]);
       useStorageStore.getState().setAll([createTestStorage()]);
       useShipsStore.getState().setAll([createTestShip()]);
+      populateActStores();
 
       expect(useSitesStore.getState().entities.size).toBe(1);
       expect(useStorageStore.getState().entities.size).toBe(1);
@@ -84,6 +126,9 @@ describe('message-handlers', () => {
       expect(useSitesStore.getState().entities.size).toBe(1);
       expect(useStorageStore.getState().entities.size).toBe(1);
       expect(useShipsStore.getState().entities.size).toBe(1);
+      expect(useWarehouseStore.getState().warehouses).toHaveLength(1);
+      expect(useExchangeStore.getState().getNaturalIdFromCode('CI1')).toBe('BEN');
+      expect(useCxobStore.getState().getByTicker('RAT.CI1')).toBeDefined();
     });
 
     it('clears all entity stores on reconnection', () => {
@@ -94,6 +139,7 @@ describe('message-handlers', () => {
       useSitesStore.getState().setAll([createTestSite()]);
       useStorageStore.getState().setAll([createTestStorage()]);
       useShipsStore.getState().setAll([createTestShip()]);
+      populateActStores();
 
       expect(useSitesStore.getState().entities.size).toBe(1);
       expect(useStorageStore.getState().entities.size).toBe(1);
@@ -105,6 +151,11 @@ describe('message-handlers', () => {
       expect(useSitesStore.getState().entities.size).toBe(0);
       expect(useStorageStore.getState().entities.size).toBe(0);
       expect(useShipsStore.getState().entities.size).toBe(0);
+      // Stale ACT data after a WS gap is exactly the staleness hazard —
+      // order books especially must not survive a reconnect.
+      expect(useWarehouseStore.getState().warehouses).toHaveLength(0);
+      expect(useExchangeStore.getState().getNaturalIdFromCode('CI1')).toBeUndefined();
+      expect(useCxobStore.getState().getByTicker('RAT.CI1')).toBeUndefined();
     });
 
     it('clears per-site sources on reconnection', () => {
@@ -492,6 +543,87 @@ describe('message-handlers', () => {
       );
 
       warnSpy.mockRestore();
+    });
+  });
+
+  describe('WAREHOUSE_STORAGES', () => {
+    // The game folds warehouse/store data together in three observed shapes;
+    // the handler must tolerate all of them (see extractWarehouse).
+    const address = {
+      lines: [
+        { type: 'SYSTEM', entity: { naturalId: 'CI' } },
+        { type: 'STATION', entity: { naturalId: 'CI1' } },
+      ],
+    };
+
+    it('shape 1: top-level storeId', () => {
+      dispatchMessage('WAREHOUSE_STORAGES', {
+        storages: [{ warehouseId: 'w1', storeId: 'store-1', address }],
+      });
+
+      const loc = useWarehouseStore.getState().getByEntityNaturalId('CI1');
+      expect(loc).toEqual({
+        warehouseId: 'w1',
+        storeId: 'store-1',
+        systemNaturalId: 'CI',
+        stationNaturalId: 'CI1',
+      });
+    });
+
+    it('shape 2: embedded store object — storeId taken from it AND the store lands in the storage store', () => {
+      const embedded = createTestStorage({ id: 'store-2', type: 'WAREHOUSE_STORE' });
+      dispatchMessage('WAREHOUSE_STORAGES', {
+        storages: [{ warehouseId: 'w2', store: embedded, address }],
+      });
+
+      expect(useWarehouseStore.getState().getByEntityNaturalId('CI1')?.storeId).toBe('store-2');
+      expect(useStorageStore.getState().getById('store-2')?.type).toBe('WAREHOUSE_STORE');
+    });
+
+    it('shape 3: entry is itself a Store object — id used as storeId, inventory reaches the storage store', () => {
+      const storeEntry = {
+        ...createTestStorage({ id: 'store-3', type: 'WAREHOUSE_STORE' }),
+        warehouseId: 'w3',
+        address,
+      };
+      dispatchMessage('WAREHOUSE_STORAGES', { storages: [storeEntry] });
+
+      expect(useWarehouseStore.getState().getByEntityNaturalId('CI1')?.storeId).toBe('store-3');
+      expect(useStorageStore.getState().getById('store-3')).toBeDefined();
+    });
+
+    it('missing storeId everywhere yields the documented "" sentinel, not a bogus id', () => {
+      dispatchMessage('WAREHOUSE_STORAGES', {
+        storages: [{ warehouseId: 'w4', address }],
+      });
+
+      expect(useWarehouseStore.getState().getByEntityNaturalId('CI1')?.storeId).toBe('');
+    });
+
+    it('accepts "warehouses" as the array field name', () => {
+      dispatchMessage('WAREHOUSE_STORAGES', {
+        warehouses: [{ warehouseId: 'w5', storeId: 's5', address }],
+      });
+
+      expect(useWarehouseStore.getState().warehouses).toHaveLength(1);
+    });
+
+    it('malformed payload increments discardedMessages and stores nothing', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      dispatchMessage('WAREHOUSE_STORAGES', { nope: true });
+
+      expect(useWarehouseStore.getState().warehouses).toHaveLength(0);
+      expect(useConnectionStore.getState().discardedMessages).toBe(1);
+      warnSpy.mockRestore();
+    });
+
+    it('WAREHOUSE_STORAGE upserts a single warehouse; WAREHOUSE_STORAGE_REMOVED drops it', () => {
+      dispatchMessage('WAREHOUSE_STORAGE', { warehouseId: 'w6', storeId: 's6', address });
+      expect(useWarehouseStore.getState().warehouses).toHaveLength(1);
+
+      dispatchMessage('WAREHOUSE_STORAGE_REMOVED', { warehouseId: 'w6' });
+      expect(useWarehouseStore.getState().warehouses).toHaveLength(0);
     });
   });
 

--- a/stores/__tests__/warehouses.test.ts
+++ b/stores/__tests__/warehouses.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useWarehouseStore } from '../warehouses';
+
+beforeEach(() => {
+  useWarehouseStore.getState().clear();
+});
+
+describe('warehouse store', () => {
+  it('finds a warehouse by stationNaturalId (CX code)', () => {
+    useWarehouseStore.getState().setWarehouses([
+      { warehouseId: 'w1', storeId: 's1', systemNaturalId: 'CI', stationNaturalId: 'CI1' },
+      { warehouseId: 'w2', storeId: 's2', systemNaturalId: 'NC', stationNaturalId: 'NC1' },
+    ]);
+
+    expect(useWarehouseStore.getState().getByEntityNaturalId('CI1')?.storeId).toBe('s1');
+    expect(useWarehouseStore.getState().getByEntityNaturalId('NC1')?.storeId).toBe('s2');
+  });
+
+  it('falls back to systemNaturalId when stationNaturalId is null', () => {
+    useWarehouseStore.getState().setWarehouses([
+      { warehouseId: 'w3', storeId: 's3', systemNaturalId: 'IC', stationNaturalId: null },
+    ]);
+
+    expect(useWarehouseStore.getState().getByEntityNaturalId('IC')?.storeId).toBe('s3');
+  });
+
+  it('returns undefined for an unknown naturalId', () => {
+    expect(useWarehouseStore.getState().getByEntityNaturalId('UNKNOWN')).toBeUndefined();
+  });
+
+  it('addWarehouse replaces an existing entry with the same warehouseId', () => {
+    const store = useWarehouseStore.getState();
+    store.addWarehouse({ warehouseId: 'w1', storeId: 's1', systemNaturalId: 'CI', stationNaturalId: 'CI1' });
+    store.addWarehouse({ warehouseId: 'w1', storeId: 's9', systemNaturalId: 'CI', stationNaturalId: 'CI1' });
+
+    expect(useWarehouseStore.getState().warehouses).toHaveLength(1);
+    expect(useWarehouseStore.getState().getByEntityNaturalId('CI1')?.storeId).toBe('s9');
+  });
+
+  it('removeWarehouse drops the entry', () => {
+    const store = useWarehouseStore.getState();
+    store.setWarehouses([
+      { warehouseId: 'w1', storeId: 's1', systemNaturalId: 'CI', stationNaturalId: 'CI1' },
+    ]);
+    store.removeWarehouse('w1');
+
+    expect(useWarehouseStore.getState().warehouses).toHaveLength(0);
+  });
+});

--- a/stores/cxob.ts
+++ b/stores/cxob.ts
@@ -1,0 +1,31 @@
+/**
+ * CX order books keyed by full CX ticker (e.g. "RAT.CI1"), from
+ * COMEX_BROKER_DATA. Gives the ACT engine price/depth for CX Buy steps.
+ * Not persisted — order books go stale in minutes; cleared on reconnect.
+ *
+ * Adapted from jackinabox86's APXM fork (https://github.com/jackinabox86/APXM).
+ */
+
+import { create } from 'zustand';
+import type { PrunApi } from '../types/prun-api';
+
+interface CxobState {
+  orderBooks: Map<string, PrunApi.CXOrderBook>;
+  getByTicker: (cxTicker: string) => PrunApi.CXOrderBook | undefined;
+  setOrderBook: (cxTicker: string, book: PrunApi.CXOrderBook) => void;
+  clear: () => void;
+}
+
+export const useCxobStore = create<CxobState>((set, get) => ({
+  orderBooks: new Map(),
+
+  getByTicker: (cxTicker) => get().orderBooks.get(cxTicker),
+
+  setOrderBook: (cxTicker, book) => {
+    const orderBooks = new Map(get().orderBooks);
+    orderBooks.set(cxTicker, book);
+    set({ orderBooks });
+  },
+
+  clear: () => set({ orderBooks: new Map() }),
+}));

--- a/stores/exchanges.ts
+++ b/stores/exchanges.ts
@@ -1,0 +1,49 @@
+/**
+ * Dynamic CX exchange code → station naturalId mapping, learned from
+ * COMEX_BROKER_DATA (which only arrives when a CX buffer is opened).
+ * Consumers should fall back to the static CX constant map for login-time
+ * lookups. Not persisted — cleared on reconnect.
+ *
+ * Adapted from jackinabox86's APXM fork (https://github.com/jackinabox86/APXM).
+ */
+
+import { create } from 'zustand';
+
+interface ExchangeEntry {
+  /** Exchange code, e.g. "AI1". */
+  code: string;
+  /** Station entity naturalId, e.g. "ANT". */
+  naturalId: string;
+}
+
+interface ExchangeState {
+  exchanges: ExchangeEntry[];
+  setExchange: (code: string, naturalId: string) => void;
+  getNaturalIdFromCode: (code: string) => string | undefined;
+  getCodeFromNaturalId: (naturalId: string) => string | undefined;
+  clear: () => void;
+}
+
+export const useExchangeStore = create<ExchangeState>((set, get) => ({
+  exchanges: [],
+
+  setExchange: (code, naturalId) =>
+    set((state) => {
+      const idx = state.exchanges.findIndex((e) => e.code === code);
+      if (idx >= 0) {
+        if (state.exchanges[idx].naturalId === naturalId) return state;
+        const updated = [...state.exchanges];
+        updated[idx] = { code, naturalId };
+        return { exchanges: updated };
+      }
+      return { exchanges: [...state.exchanges, { code, naturalId }] };
+    }),
+
+  getNaturalIdFromCode: (code) =>
+    get().exchanges.find((e) => e.code === code)?.naturalId,
+
+  getCodeFromNaturalId: (naturalId) =>
+    get().exchanges.find((e) => e.naturalId === naturalId)?.code,
+
+  clear: () => set({ exchanges: [] }),
+}));

--- a/stores/message-handlers.ts
+++ b/stores/message-handlers.ts
@@ -17,6 +17,9 @@ import {
 } from './entities';
 import { useSiteSourceStore } from './site-data-sources';
 import { useCompanyStore } from './company';
+import { useWarehouseStore, type WarehouseLocation } from './warehouses';
+import { useExchangeStore } from './exchanges';
+import { useCxobStore } from './cxob';
 
 type MessageHandler = (msg: ProcessedMessage) => void;
 const typeHandlers = new Map<string, MessageHandler>();
@@ -104,6 +107,12 @@ export function initMessageHandlers(): void {
       // markers re-accumulate as per-site data arrives.
       useCompanyStore.getState().clear();
       useProductionLoadedStore.getState().clear();
+      // ACT-engine stores: warehouses re-arrive with the login dump;
+      // exchange mappings and order books re-learn from CX buffers.
+      // Order books especially must not survive a gap in observation.
+      useWarehouseStore.getState().clear();
+      useExchangeStore.getState().clear();
+      useCxobStore.getState().clear();
     }
     useConnectionStore.getState().incrementReconnectCount();
     useConnectionStore.getState().setConnected(true);
@@ -491,6 +500,197 @@ export function initMessageHandlers(): void {
       warn('COMPANY_DATA: unexpected payload structure', payload);
       useConnectionStore.getState().incrementDiscarded();
     }
+  });
+
+  // ============================================================================
+  // Warehouses (CX storage locations — ACT engine foundation)
+  // ============================================================================
+  // Extraction logic adapted from jackinabox86's APXM fork: the game folds
+  // warehouse and store data together inconsistently, so both parsers below
+  // tolerate the three observed shapes.
+
+  // Parse one warehouse wire entry into a WarehouseLocation, or null if the
+  // required identity/address fields are missing.
+  function extractWarehouse(wh: Record<string, unknown>): WarehouseLocation | null {
+    const warehouseId = wh.warehouseId;
+    if (typeof warehouseId !== 'string') return null;
+
+    // storeId may live at the top level ("storeId"/"storageId"), be embedded
+    // in a "store"/"storage" sub-object, or be absent entirely (inventory
+    // sent separately via STORAGE_STORAGES). '' is the documented sentinel —
+    // consumers cross-reference via Store.addressableId instead.
+    const embeddedStoreObj = (wh.store ?? wh.storage) as
+      | Record<string, unknown>
+      | undefined;
+    // wh.id is a fallback for when the entry is itself a Store object; the
+    // same UUID as warehouseId means it's the warehouse id, not a store id.
+    const whId = typeof wh.id === 'string' && wh.id !== warehouseId ? wh.id : undefined;
+    const storeId = (wh.storeId ??
+      wh.storageId ??
+      embeddedStoreObj?.id ??
+      whId ??
+      '') as string;
+
+    const address = wh.address as
+      | { lines?: Array<{ type?: string; entity?: { naturalId?: string } }> }
+      | undefined;
+    const systemNaturalId = address?.lines?.find((l) => l.type === 'SYSTEM')?.entity
+      ?.naturalId;
+    if (typeof systemNaturalId !== 'string') return null;
+    const stationEntity = address?.lines?.find((l) => l.type === 'STATION')?.entity;
+    const stationNaturalId =
+      typeof stationEntity?.naturalId === 'string' ? stationEntity.naturalId : null;
+
+    return { warehouseId, storeId, systemNaturalId, stationNaturalId };
+  }
+
+  // Extract an embedded PrunApi.Store from a warehouse entry if present, so
+  // warehouse inventory reaches the storage store even when STORAGE_STORAGES
+  // doesn't carry it separately.
+  function extractEmbeddedStore(wh: Record<string, unknown>): PrunApi.Store | null {
+    // Shape 1: store data nested in a "store"/"storage" sub-object.
+    const s = (wh.store ?? wh.storage) as Record<string, unknown> | undefined;
+    if (s && typeof s.id === 'string' && typeof s.type === 'string') {
+      return s as unknown as PrunApi.Store;
+    }
+    // Shape 2: the entry is itself a Store object — identified by a top-level
+    // "items" array (inventory) alongside "warehouseId".
+    if (
+      typeof wh.id === 'string' &&
+      typeof wh.type === 'string' &&
+      Array.isArray(wh.items)
+    ) {
+      return wh as unknown as PrunApi.Store;
+    }
+    return null;
+  }
+
+  typeHandlers.set('WAREHOUSE_STORAGES', (msg: ProcessedMessage) => {
+    const payload = extractPayload(msg) as Record<string, unknown> | null;
+    // The game uses "storages" or "warehouses" as the array field name.
+    const raw = payload?.storages ?? payload?.warehouses;
+    if (!Array.isArray(raw)) {
+      warn('WAREHOUSE_STORAGES: unexpected payload structure', payload);
+      useConnectionStore.getState().incrementDiscarded();
+      return;
+    }
+    const locations: WarehouseLocation[] = [];
+    const embeddedStores: PrunApi.Store[] = [];
+    for (const wh of raw as unknown[]) {
+      if (!wh || typeof wh !== 'object') continue;
+      const loc = extractWarehouse(wh as Record<string, unknown>);
+      if (loc) locations.push(loc);
+      const embedded = extractEmbeddedStore(wh as Record<string, unknown>);
+      if (embedded) embeddedStores.push(embedded);
+    }
+    useWarehouseStore.getState().setWarehouses(locations);
+    if (embeddedStores.length > 0) {
+      useStorageStore.getState().setMany(embeddedStores);
+    }
+  });
+
+  typeHandlers.set('WAREHOUSE_STORAGE', (msg: ProcessedMessage) => {
+    const payload = extractPayload(msg) as Record<string, unknown> | null;
+    if (payload && typeof payload === 'object') {
+      const loc = extractWarehouse(payload);
+      if (loc) {
+        useWarehouseStore.getState().addWarehouse(loc);
+        const embedded = extractEmbeddedStore(payload);
+        if (embedded) useStorageStore.getState().setOne(embedded);
+        return;
+      }
+    }
+    warn('WAREHOUSE_STORAGE: unexpected payload structure', payload);
+    useConnectionStore.getState().incrementDiscarded();
+  });
+
+  typeHandlers.set('WAREHOUSE_STORAGE_REMOVED', (msg: ProcessedMessage) => {
+    const payload = extractPayload(msg) as { warehouseId?: string };
+    if (typeof payload?.warehouseId === 'string') {
+      useWarehouseStore.getState().removeWarehouse(payload.warehouseId);
+    } else {
+      warn('WAREHOUSE_STORAGE_REMOVED: unexpected payload structure', payload);
+      useConnectionStore.getState().incrementDiscarded();
+    }
+  });
+
+  // ============================================================================
+  // Commodity Exchange — order books (ACT engine foundation)
+  // ============================================================================
+  // Arrives when a CX buffer is open. Also teaches the dynamic exchange
+  // code → station naturalId mapping. Parsing adapted from jackinabox86's fork.
+
+  typeHandlers.set('COMEX_BROKER_DATA', (msg: ProcessedMessage) => {
+    const payload = extractPayload(msg) as Record<string, unknown> | null;
+    if (!payload || typeof payload !== 'object') {
+      warn('COMEX_BROKER_DATA: unexpected payload structure', payload);
+      useConnectionStore.getState().incrementDiscarded();
+      return;
+    }
+
+    // Exchange code from the exchange sub-object or the flat field.
+    let exchangeCode: string | undefined;
+    if (typeof payload.exchangeCode === 'string') {
+      exchangeCode = payload.exchangeCode;
+    } else if (payload.exchange && typeof payload.exchange === 'object') {
+      const code = (payload.exchange as Record<string, unknown>).code;
+      if (typeof code === 'string') exchangeCode = code;
+    }
+
+    // Full CX ticker ("RAT.CI1"): payload.ticker may already be full, or be
+    // the material part only; payload.material.ticker is always material-only.
+    let cxTicker: string | undefined;
+    if (typeof payload.ticker === 'string') {
+      if (payload.ticker.includes('.')) {
+        cxTicker = payload.ticker;
+        if (!exchangeCode) {
+          const dot = payload.ticker.lastIndexOf('.');
+          if (dot > 0) exchangeCode = payload.ticker.slice(dot + 1);
+        }
+      } else if (exchangeCode) {
+        cxTicker = `${payload.ticker}.${exchangeCode}`;
+      }
+    } else if (payload.material && typeof payload.material === 'object') {
+      const ticker = (payload.material as Record<string, unknown>).ticker;
+      if (typeof ticker === 'string' && exchangeCode) {
+        cxTicker = `${ticker}.${exchangeCode}`;
+      }
+    }
+
+    if (!cxTicker || !exchangeCode) {
+      warn('COMEX_BROKER_DATA: could not parse ticker/exchange', payload);
+      useConnectionStore.getState().incrementDiscarded();
+      return;
+    }
+
+    // The exchange object carries no naturalId, but the address always has a
+    // STATION line — feed the dynamic code→naturalId mapping from it.
+    const address = payload.address as
+      | { lines?: Array<{ type?: string; entity?: { naturalId?: string } }> }
+      | undefined;
+    const stationNaturalId = address?.lines?.find((l) => l.type === 'STATION')?.entity
+      ?.naturalId;
+    if (typeof stationNaturalId === 'string') {
+      useExchangeStore.getState().setExchange(exchangeCode, stationNaturalId);
+    }
+
+    function parseOrders(raw: unknown): PrunApi.CXOrder[] {
+      if (!Array.isArray(raw)) return [];
+      return raw.flatMap((o) => {
+        if (!o || typeof o !== 'object') return [];
+        const order = o as Record<string, unknown>;
+        const limit = order.limit as Record<string, unknown> | undefined;
+        if (typeof limit?.amount !== 'number') return [];
+        const rawAmount = order.amount ?? order.itemCount ?? null;
+        const amount = typeof rawAmount === 'number' ? rawAmount : null;
+        return [{ amount, limit: { amount: limit.amount } }];
+      });
+    }
+
+    useCxobStore.getState().setOrderBook(cxTicker, {
+      sellingOrders: parseOrders(payload.sellingOrders),
+      buyingOrders: parseOrders(payload.buyingOrders),
+    });
   });
 
 }

--- a/stores/settings.ts
+++ b/stores/settings.ts
@@ -42,6 +42,9 @@ interface SettingsState {
   /** User's Status-tab panel order. Untrusted (storage) — reconciled against
    *  STATUS_PANEL_IDS by the view, which drops unknowns and appends new panels. */
   statusPanelOrder: string[];
+  /** Material tickers the ACT engine must never generate CX Buy steps for.
+   *  No UI yet — consumed by the engine port (#25/#28). */
+  noBuy: string[];
 }
 
 interface SettingsActions {
@@ -53,6 +56,7 @@ interface SettingsActions {
   setUiTheme: (theme: ApxmThemeId) => void;
   setRprunFeaturesDisabled: (disabled: boolean) => void;
   setStatusPanelOrder: (order: string[]) => void;
+  setNoBuy: (tickers: string[]) => void;
   reset: () => void;
 }
 
@@ -77,6 +81,7 @@ const initialState: SettingsState = {
   uiTheme: DEFAULT_THEME_ID,
   rprunFeaturesDisabled: false,
   statusPanelOrder: [...STATUS_PANEL_IDS],
+  noBuy: [],
 };
 
 // Check if browser storage API is available
@@ -172,6 +177,8 @@ export const useSettingsStore = create<SettingsStore>()(
       setRprunFeaturesDisabled: (disabled) => set({ rprunFeaturesDisabled: disabled }),
 
       setStatusPanelOrder: (order) => set({ statusPanelOrder: order }),
+
+      setNoBuy: (tickers) => set({ noBuy: tickers }),
 
       reset: () => set(initialState),
     }),

--- a/stores/warehouses.ts
+++ b/stores/warehouses.ts
@@ -1,0 +1,64 @@
+/**
+ * CX warehouse locations, from WAREHOUSE_STORAGES / WAREHOUSE_STORAGE.
+ *
+ * A warehouse is where CX-bought goods land, so the ACT engine needs to map
+ * an exchange (station or system naturalId) to the warehouse's storage id.
+ * Not persisted — repopulated by the login dump, cleared on reconnect.
+ *
+ * Adapted from jackinabox86's APXM fork (https://github.com/jackinabox86/APXM).
+ */
+
+import { create } from 'zustand';
+
+export interface WarehouseLocation {
+  warehouseId: string;
+  /** May be '' when the wire message carried no resolvable store id — the
+   *  consumer must then cross-reference via Store.addressableId. */
+  storeId: string;
+  systemNaturalId: string;
+  stationNaturalId: string | null;
+}
+
+interface WarehouseState {
+  warehouses: WarehouseLocation[];
+  setWarehouses: (warehouses: WarehouseLocation[]) => void;
+  addWarehouse: (warehouse: WarehouseLocation) => void;
+  removeWarehouse: (warehouseId: string) => void;
+  getBySystem: (systemNaturalId: string) => WarehouseLocation | undefined;
+  getByEntityNaturalId: (naturalId: string) => WarehouseLocation | undefined;
+  clear: () => void;
+}
+
+export const useWarehouseStore = create<WarehouseState>((set, get) => ({
+  warehouses: [],
+
+  setWarehouses: (warehouses) => set({ warehouses }),
+
+  addWarehouse: (warehouse) =>
+    set((state) => {
+      const existing = state.warehouses.findIndex(
+        (w) => w.warehouseId === warehouse.warehouseId
+      );
+      if (existing >= 0) {
+        const updated = [...state.warehouses];
+        updated[existing] = warehouse;
+        return { warehouses: updated };
+      }
+      return { warehouses: [...state.warehouses, warehouse] };
+    }),
+
+  removeWarehouse: (warehouseId) =>
+    set((state) => ({
+      warehouses: state.warehouses.filter((w) => w.warehouseId !== warehouseId),
+    })),
+
+  getBySystem: (systemNaturalId) =>
+    get().warehouses.find((w) => w.systemNaturalId === systemNaturalId),
+
+  // Station match first (exchange code == station naturalId), then system.
+  getByEntityNaturalId: (naturalId) =>
+    get().warehouses.find((w) => w.stationNaturalId === naturalId) ??
+    get().warehouses.find((w) => w.systemNaturalId === naturalId),
+
+  clear: () => set({ warehouses: [] }),
+}));

--- a/types/prun-api.ts
+++ b/types/prun-api.ts
@@ -143,6 +143,21 @@ export namespace PrunApi {
   }
 
   // ============================================================================
+  // Commodity Exchange Order Book (COMEX_BROKER_DATA)
+  // ============================================================================
+
+  export interface CXOrder {
+    /** Units offered/requested. null = a market maker's infinite order. */
+    amount: number | null;
+    limit: { amount: number };
+  }
+
+  export interface CXOrderBook {
+    sellingOrders: CXOrder[];
+    buyingOrders: CXOrder[];
+  }
+
+  // ============================================================================
   // Site Types
   // ============================================================================
 


### PR DESCRIPTION
Phase B of the #25/#28 build (per the agreed plan: engine runs in APXM, automation level is a settings dial). Pure data-layer foundations — **no visible behavior change**.

## What's added

- `stores/warehouses.ts` — CX warehouse locations from `WAREHOUSE_STORAGES` / `WAREHOUSE_STORAGE` / `WAREHOUSE_STORAGE_REMOVED`, with the fork's tolerant extraction (storeId can live in three places; embedded Store objects are pushed into the storage store)
- `stores/exchanges.ts` — dynamic exchange code → station naturalId mapping, learned from CX buffer data
- `stores/cxob.ts` — CX order books keyed by full CX ticker (`RAT.CI1`) from `COMEX_BROKER_DATA`
- `PrunApi.CXOrder` / `CXOrderBook` types; `settings.noBuy` (engine-consumed, no UI yet)
- All three stores clear on `CLIENT_CONNECTION_OPENED` reconnect (the fork only cleared exchanges — per the staleness rule, stale order books are worse than none)

## Deliberately not ported

The fork's WS materials store (`WORLD_MATERIAL_CATEGORIES`): the engine only reads material `weight`/`volume`, which APXM's FIO reference store already provides. `_compat` will adapt to it in the next phase. The fork's raw `console.log` diagnostics were replaced with the `__DEV__`-gated logger + `incrementDiscarded` per house style.

## Credit

Store shapes and wire-format extraction adapted from [jackinabox86's APXM fork](https://github.com/jackinabox86/APXM).

## Verification

- Typecheck clean; tests 450 → **461** (ported + extended warehouse/cxob suites, incl. all three observed COMEX payload shapes)
- Chrome + Firefox builds green

🤖 Generated with [Claude Code](https://claude.com/claude-code)