### PR TITLE
Dev-build Settings picker for buffer refresh modes

### DIFF
--- a/components/views/SettingsView.tsx
+++ b/components/views/SettingsView.tsx
@@ -9,11 +9,24 @@ import {
 import { testConnection, populateStoresFromFio, type FioProgressStep } from '../../lib/fio';
 import { clearAllCache } from '../../stores/cache';
 import { themePresets } from '../../lib/theme';
+import {
+  setRefreshMode as applyRefreshMode,
+  executeBatchRefresh,
+  type RefreshMode,
+} from '../../lib/buffer-refresh';
+import { useRefreshState } from '../../stores/refreshState';
+import { useSitesStore } from '../../stores/entities';
 
 const materialThemeOptions: { id: MaterialTheme; label: string }[] = [
   { id: 'rprun', label: 'rPrUn' },
   { id: 'prun', label: 'PrUn' },
   { id: 'drydock', label: 'DryDock' },
+];
+
+const refreshModeOptions: { id: RefreshMode; label: string }[] = [
+  { id: 'manual', label: 'Manual' },
+  { id: 'batch', label: 'Batch' },
+  { id: 'auto', label: 'Auto' },
 ];
 
 /** 24-bit hex number → CSS hex string, for inline preset-preview swatches. */
@@ -22,6 +35,74 @@ function toCssHex(value: number): string {
 }
 
 type ConnectionStatus = 'untested' | 'testing' | 'valid' | 'invalid';
+
+/**
+ * Dev-build-only refresh mode picker. Surfaces the batch/auto modes that are
+ * otherwise URL-param-gated (?apxm_refresh=…) so device testing doesn't need
+ * URL editing. Dev builds honour the persisted choice at startup
+ * (initRefreshMode); production ignores it and always starts manual.
+ */
+function DevRefreshModePane() {
+  const mode = useRefreshState((s) => s.mode);
+  const isRefreshing = useRefreshState((s) => s.isRefreshing);
+  const completedCount = useRefreshState((s) => s.completedCount);
+  const totalCount = useRefreshState((s) => s.totalCount);
+  const persistRefreshMode = useSettingsStore((s) => s.setRefreshMode);
+
+  function selectMode(next: RefreshMode): void {
+    applyRefreshMode(next); // runtime: module var + refreshState store
+    persistRefreshMode(next); // storage: read back at next startup (dev only)
+  }
+
+  function handleRefreshAll(): void {
+    if (isRefreshing) return;
+    const siteIds = useSitesStore
+      .getState()
+      .getAll()
+      .map((s) => s.siteId);
+    if (siteIds.length === 0) return;
+    executeBatchRefresh({ siteIds });
+  }
+
+  return (
+    <Panel title="Refresh Mode" code="DEV">
+      <div className="space-y-3">
+        <div className="flex gap-2">
+          {refreshModeOptions.map((option) => (
+            <button
+              key={option.id}
+              onClick={() => selectMode(option.id)}
+              className={`flex-1 min-h-touch px-4 py-2 font-mono text-[11px] font-semibold uppercase tracking-wider ${
+                mode === option.id
+                  ? 'bg-prun-yellow text-apxm-bg'
+                  : 'border border-apxm-accent text-apxm-muted'
+              }`}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+
+        <p className="text-xs text-apxm-muted">
+          Manual: per-base refresh buttons. Batch: adds Refresh All below. Auto:
+          refreshes every base after login — applies from the next reload.
+        </p>
+
+        {mode === 'batch' && (
+          <button
+            onClick={handleRefreshAll}
+            disabled={isRefreshing}
+            className={`${btnSecondary} w-full min-h-touch`}
+          >
+            {isRefreshing
+              ? `Refreshing ${completedCount}/${totalCount}…`
+              : 'Refresh all bases'}
+          </button>
+        )}
+      </div>
+    </Panel>
+  );
+}
 
 const STEP_LABELS: Record<FioProgressStep, string> = {
   sites: 'Sites',
@@ -529,6 +610,8 @@ export function SettingsView() {
           </div>
         </div>
       </Panel>
+
+      {__DEV__ && <DevRefreshModePane />}
     </div>
   );
 }

--- a/lib/buffer-refresh/mode-controller.ts
+++ b/lib/buffer-refresh/mode-controller.ts
@@ -10,16 +10,24 @@
 
 import type { RefreshMode } from './types';
 import { useRefreshState } from '../../stores/refreshState';
+import { useSettingsStore } from '../../stores/settings';
 
 let currentMode: RefreshMode = 'manual';
 
-/** Initialize mode from URL param. Call once at startup. */
+/**
+ * Initialize mode. Call once at startup, after settings hydration.
+ * URL param wins; dev builds then honour the persisted Settings choice
+ * (the auto mode only acts at startup, so it needs persistence to be
+ * usable at all). Production without a param always starts 'manual'.
+ */
 export function initRefreshMode(): void {
   const params = new URLSearchParams(location.search);
   const param = params.get('apxm_refresh');
 
   if (param === 'manual' || param === 'batch' || param === 'auto') {
     currentMode = param;
+  } else if (__DEV__) {
+    currentMode = useSettingsStore.getState().refreshMode;
   } else {
     currentMode = 'manual';
   }

--- a/stores/settings.ts
+++ b/stores/settings.ts
@@ -3,6 +3,7 @@ import { persist, createJSONStorage, type StateStorage } from 'zustand/middlewar
 import { browser } from 'wxt/browser';
 import { DEFAULT_THEME_ID, type ApxmThemeId } from '../lib/theme';
 import type { MaterialTheme } from '../lib/material-colors';
+import type { RefreshMode } from '../lib/buffer-refresh/types';
 
 // Re-exported so settings consumers don't need a second import; the palette
 // module owns the definition (it changes when palettes are added).
@@ -42,6 +43,10 @@ interface SettingsState {
   /** User's Status-tab panel order. Untrusted (storage) — reconciled against
    *  STATUS_PANEL_IDS by the view, which drops unknowns and appends new panels. */
   statusPanelOrder: string[];
+  /** Buffer refresh trigger mode. Only dev builds surface a picker and honour
+   *  the persisted value at startup; production always starts 'manual'
+   *  (the apxm_refresh URL param overrides either way). */
+  refreshMode: RefreshMode;
 }
 
 interface SettingsActions {
@@ -53,6 +58,7 @@ interface SettingsActions {
   setUiTheme: (theme: ApxmThemeId) => void;
   setRprunFeaturesDisabled: (disabled: boolean) => void;
   setStatusPanelOrder: (order: string[]) => void;
+  setRefreshMode: (mode: RefreshMode) => void;
   reset: () => void;
 }
 
@@ -77,6 +83,7 @@ const initialState: SettingsState = {
   uiTheme: DEFAULT_THEME_ID,
   rprunFeaturesDisabled: false,
   statusPanelOrder: [...STATUS_PANEL_IDS],
+  refreshMode: 'manual',
 };
 
 // Check if browser storage API is available
@@ -172,6 +179,8 @@ export const useSettingsStore = create<SettingsStore>()(
       setRprunFeaturesDisabled: (disabled) => set({ rprunFeaturesDisabled: disabled }),
 
       setStatusPanelOrder: (order) => set({ statusPanelOrder: order }),
+
+      setRefreshMode: (mode) => set({ refreshMode: mode }),
 
       reset: () => set(initialState),
     }),


### PR DESCRIPTION
Surfaces the existing manual/batch/auto buffer-refresh modes — previously reachable only via the `?apxm_refresh` URL param — as a DEV-tagged Settings panel. First step of the #25/#28 direction: automation level as a user-visible setting, capability built but gated.

- New `settings.refreshMode` (persisted). **Dev builds only** honour it at startup; production ignores it and always starts manual. The URL param overrides both.
- Batch mode gains a **Refresh all bases** button in the pane (with live progress) — batch previously had no UI trigger at all.
- Panel is `__DEV__`-gated: invisible in production builds.

## Verification
- Typecheck clean, 450/450 tests, both builds green
- Device-testable from `~/Downloads/apxm-dev` (Settings → bottom panel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)