### PR TITLE
Test hardening: fix silent-pass failures from the suite audit

### DIFF
--- a/components/shared/__tests__/DataGate.test.ts
+++ b/components/shared/__tests__/DataGate.test.ts
@@ -17,6 +17,14 @@ describe('resolveGate', () => {
       const result = resolveGate([], 'connecting', false, 0, false);
       expect(result.state).toBe('ready');
     });
+
+    it('ready beats unresponsive — fetched data always renders', () => {
+      // Top link of the priority chain: even with the unresponsive flags all
+      // set, complete data must show (stale-but-present beats an error page).
+      const stores = [store('sites', true, true)];
+      const result = resolveGate(stores, 'connecting', false, 0, true);
+      expect(result.state).toBe('ready');
+    });
   });
 
   describe('unresponsive APEX', () => {

--- a/components/status/__tests__/reorder-utils.test.ts
+++ b/components/status/__tests__/reorder-utils.test.ts
@@ -30,6 +30,15 @@ describe('reconcileOrder', () => {
       'empire',
     ]);
   });
+
+  it('dedupes a corrupted saved order (a repeated id must not render a panel twice)', () => {
+    expect(reconcileOrder(['fleet', 'fleet', 'bases'])).toEqual([
+      'fleet',
+      'bases',
+      'contracts',
+      'empire',
+    ]);
+  });
 });
 
 describe('applyReorder', () => {

--- a/components/status/reorder-utils.ts
+++ b/components/status/reorder-utils.ts
@@ -14,7 +14,9 @@ function move<T>(arr: T[], from: number, to: number): T[] {
  * removed, or renamed.
  */
 export function reconcileOrder(stored: string[]): StatusPanelId[] {
-  const known = stored.filter((id): id is StatusPanelId =>
+  // Set-dedupe: a corrupted saved order with a repeated id would otherwise
+  // render the same panel twice (duplicate React keys).
+  const known = [...new Set(stored)].filter((id): id is StatusPanelId =>
     (STATUS_PANEL_IDS as string[]).includes(id)
   );
   const missing = STATUS_PANEL_IDS.filter((id) => !known.includes(id));

--- a/components/views/__tests__/SettingsView.test.ts
+++ b/components/views/__tests__/SettingsView.test.ts
@@ -29,8 +29,13 @@ describe('SettingsView repair threshold validation', () => {
       useSettingsStore.getState().reset();
     });
 
-    it('defaults match DEFAULT_REPAIR_THRESHOLDS (60/10)', () => {
-      expect(useSettingsStore.getState().repairThresholds).toEqual(DEFAULT_REPAIR_THRESHOLDS);
+    it('defaults are 60/10 (rPrun-XIT-REP values proven on jackinabox86 fork)', () => {
+      // Assert the literals, not just equality with the constant — the store
+      // initializes FROM that constant, so toEqual alone is circular.
+      const { repairThresholds } = useSettingsStore.getState();
+      expect(repairThresholds.threshold).toBe(60);
+      expect(repairThresholds.offset).toBe(10);
+      expect(repairThresholds).toEqual(DEFAULT_REPAIR_THRESHOLDS);
     });
 
     it('setRepairThresholds persists partial updates', () => {

--- a/components/views/hooks/__tests__/useContractDetails.test.ts
+++ b/components/views/hooks/__tests__/useContractDetails.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildContractDetail } from '../useContractDetails';
+import { buildContractDetail, assembleContractDetails } from '../useContractDetails';
 import { createTestContract, createContractCondition } from '../../../../__tests__/fixtures/factories';
 import type { PrunApi } from '../../../../types/prun-api';
 
@@ -99,6 +99,9 @@ describe('buildContractDetail — dependency-aware condition flags', () => {
       'TERMINATED',
       'BREACHED',
       'DEADLINE_EXCEEDED',
+      // FULFILLED is terminal too: a stray PENDING condition on a fulfilled
+      // contract must not resurrect an action affordance.
+      'FULFILLED',
     ];
 
     for (const status of terminalStatuses) {
@@ -204,5 +207,67 @@ describe('buildContractDetail — acceptance semantics (rPrun parlance)', () => 
       partner: { id: 'p', name: 'Trade Partner Corp', code: 'TPC' },
     });
     expect(buildContractDetail(commercial).isFaction).toBe(false);
+  });
+});
+
+describe('assembleContractDetails (list sort/count/filter)', () => {
+  const DAY = 86400000;
+  const now = 1_700_000_000_000;
+
+  function contractWith(
+    localId: string,
+    status: PrunApi.ContractStatus,
+    dueMs: number | null
+  ): PrunApi.Contract {
+    return createTestContract({
+      localId,
+      status,
+      dueDate: dueMs === null ? undefined : { timestamp: dueMs },
+    });
+  }
+
+  const openLate = contractWith('OPEN-LATE', 'OPEN', now + 9 * DAY);
+  const openSoon = contractWith('OPEN-SOON', 'OPEN', now + 1 * DAY);
+  const closedSoon = contractWith('CLOSED-SOON', 'CLOSED', now + 2 * DAY);
+  const partial = contractWith('PARTIAL', 'PARTIALLY_FULFILLED', now + 5 * DAY);
+  const fulfilled = contractWith('DONE', 'FULFILLED', now + 3 * DAY);
+  const noDue = contractWith('NO-DUE', 'CLOSED', null);
+  const all = [fulfilled, noDue, closedSoon, openLate, partial, openSoon];
+
+  it('the ACTIVE bucket includes OPEN — awaiting-acceptance contracts need attention too', () => {
+    // Deliberately broader than the accepted set (CLOSED/PARTIALLY_FULFILLED):
+    // the filter answers "needs attention", acceptance gates actions.
+    const { counts } = assembleContractDetails(all, new Set(['all']));
+    expect(counts).toEqual({ all: 6, active: 5, fulfilled: 1 });
+  });
+
+  it('sorts OPEN first, then by due date, undated last', () => {
+    const { contracts } = assembleContractDetails(all, new Set(['all']));
+    expect(contracts.map((c) => c.localId)).toEqual([
+      'OPEN-SOON', // OPEN block first, soonest due leads
+      'OPEN-LATE',
+      'CLOSED-SOON', // then non-OPEN by due date
+      'DONE',
+      'PARTIAL',
+      'NO-DUE', // null due date sorts to the end
+    ]);
+  });
+
+  it('the active filter keeps OPEN/CLOSED/PARTIALLY_FULFILLED and drops FULFILLED', () => {
+    const { contracts } = assembleContractDetails(all, new Set(['active']));
+    expect(contracts.map((c) => c.localId)).toEqual([
+      'OPEN-SOON',
+      'OPEN-LATE',
+      'CLOSED-SOON',
+      'PARTIAL',
+      'NO-DUE',
+    ]);
+  });
+
+  it('the fulfilled filter keeps only FULFILLED; counts stay global', () => {
+    const { contracts, counts } = assembleContractDetails(all, new Set(['fulfilled']));
+    expect(contracts.map((c) => c.localId)).toEqual(['DONE']);
+    // Counts describe the whole set (filter-bar badges), not the filtered view.
+    expect(counts.all).toBe(6);
   });
 });

--- a/components/views/hooks/useContractDetails.ts
+++ b/components/views/hooks/useContractDetails.ts
@@ -332,45 +332,58 @@ export interface ContractDetailsResult {
 }
 
 /**
+ * Pure sort/count/filter over built contract details. Extracted from the hook
+ * for testability — the ACTIVE-includes-OPEN distinction (vs ACCEPTED_STATUSES,
+ * which deliberately excludes OPEN) lives here and must stay pinned by tests.
+ */
+export function assembleContractDetails(
+  contracts: PrunApi.Contract[],
+  activeFilters: ReadonlySet<ContractFilter>
+): ContractDetailsResult {
+  const details: ContractDetail[] = contracts.map(buildContractDetail);
+
+  // Sort: OPEN first, then by due date (contracts without a due date last)
+  details.sort((a, b) => {
+    if (a.status === 'OPEN' && b.status !== 'OPEN') return -1;
+    if (a.status !== 'OPEN' && b.status === 'OPEN') return 1;
+
+    const dateA = a.dueDateMs ?? Infinity;
+    const dateB = b.dueDateMs ?? Infinity;
+    return dateA - dateB;
+  });
+
+  // Count by filter category
+  const activeCount = details.filter((c) => ACTIVE_STATUSES.includes(c.status)).length;
+  const fulfilledCount = details.filter((c) => FULFILLED_STATUSES.includes(c.status)).length;
+
+  const counts: Record<ContractFilter, number> = {
+    all: details.length,
+    active: activeCount,
+    fulfilled: fulfilledCount,
+  };
+
+  // Apply filter
+  const filtered = activeFilters.has('all')
+    ? details
+    : details.filter((c) => {
+        if (activeFilters.has('active') && ACTIVE_STATUSES.includes(c.status)) return true;
+        if (activeFilters.has('fulfilled') && FULFILLED_STATUSES.includes(c.status)) return true;
+        return false;
+      });
+
+  return { contracts: filtered, counts };
+}
+
+/**
  * Hook that assembles contract details with conditions.
  */
 export function useContractDetails(activeFilters: ReadonlySet<ContractFilter>): ContractDetailsResult {
   const contractsLastUpdated = useContractsStore((s) => s.lastUpdated);
 
-  return useMemo(() => {
-    const contracts = useContractsStore.getState().getAll();
-
-    const details: ContractDetail[] = contracts.map(buildContractDetail);
-
-    // Sort: OPEN first, then by due date
-    details.sort((a, b) => {
-      if (a.status === 'OPEN' && b.status !== 'OPEN') return -1;
-      if (a.status !== 'OPEN' && b.status === 'OPEN') return 1;
-
-      const dateA = a.dueDateMs ?? Infinity;
-      const dateB = b.dueDateMs ?? Infinity;
-      return dateA - dateB;
-    });
-
-    // Count by filter category
-    const activeCount = details.filter((c) => ACTIVE_STATUSES.includes(c.status)).length;
-    const fulfilledCount = details.filter((c) => FULFILLED_STATUSES.includes(c.status)).length;
-
-    const counts: Record<ContractFilter, number> = {
-      all: details.length,
-      active: activeCount,
-      fulfilled: fulfilledCount,
-    };
-
-    // Apply filter
-    const filtered = activeFilters.has('all')
-      ? details
-      : details.filter((c) => {
-          if (activeFilters.has('active') && ACTIVE_STATUSES.includes(c.status)) return true;
-          if (activeFilters.has('fulfilled') && FULFILLED_STATUSES.includes(c.status)) return true;
-          return false;
-        });
-
-    return { contracts: filtered, counts };
-  }, [contractsLastUpdated, activeFilters]);
+  return useMemo(
+    () => assembleContractDetails(useContractsStore.getState().getAll(), activeFilters),
+    // contractsLastUpdated re-derives when contract data changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [contractsLastUpdated, activeFilters]
+  );
 }

--- a/core/__tests__/burn.test.ts
+++ b/core/__tests__/burn.test.ts
@@ -658,37 +658,6 @@ describe('burn.ts', () => {
       expect(Number.isFinite(ratRate?.consumption)).toBe(true);
     });
 
-    it('handles zero inventory for consumed material (returns 0, not NaN)', () => {
-      // When inventory is 0 and consuming, daysRemaining should be 0
-      const workforce = createWorkforce({
-        needs: [
-          createNeed({
-            material: createMaterial({ ticker: 'RAT' }),
-            unitsPerInterval: 10,
-          }),
-        ],
-      });
-
-      const wfRates = calculateWorkforceConsumption([workforce]);
-      const inventory = new Map<string, number>();
-      // No RAT in inventory
-
-      const consumption = wfRates.get('RAT')?.consumption ?? 0;
-      const dailyAmount = -consumption;
-      const inventoryAmount = inventory.get('RAT') ?? 0;
-
-      // Replicate daysRemaining calculation from calculateSiteBurn
-      const daysRemaining =
-        dailyAmount >= 0
-          ? Infinity
-          : inventoryAmount === 0
-            ? 0
-            : inventoryAmount / Math.abs(dailyAmount);
-
-      expect(Number.isNaN(daysRemaining)).toBe(false);
-      expect(daysRemaining).toBe(0);
-    });
-
     it('all burn calculations return finite or Infinity daysRemaining, never NaN', () => {
       // Set up a site with workforce consuming materials with zero inventory
       const siteId = 'nan-test-site';
@@ -972,6 +941,38 @@ describe('burn.ts', () => {
       const lseBurn = result.burns.find((b) => b.materialTicker === 'LSE');
       expect(lseBurn?.daysRemaining).toBe(Infinity);
       expect(lseBurn?.urgency).toBe('surplus');
+    });
+
+    it('treats a near-balanced net rate as balanced at the site level (NET_RATE_EPSILON)', () => {
+      // The empire path already covers the epsilon; the site path must stay
+      // covered independently in case the shared buildBurnRate helper is ever
+      // split per-path (see issue #31).
+      // One order, capacity 1, 1-day duration: output 10/day, input 10.0005/day
+      // of the same ticker → net = 10 - 10.0005 = -0.0005/day. That is inside
+      // NET_RATE_EPSILON (0.001), so it is floating-point noise from a balanced
+      // chain, not real consumption.
+      const order = createOrderWithIO(
+        [{ ticker: 'RAT', amount: 10.0005 }],
+        [{ ticker: 'RAT', amount: 10 }],
+        MS_PER_DAY
+      );
+      const prodLine = createTestProductionLine({
+        siteId,
+        orders: [order],
+        capacity: 1,
+      });
+      useProductionStore.getState().setOne(prodLine);
+
+      const store = createStorageWithItems(siteId, [{ ticker: 'RAT', amount: 50 }]);
+      useStorageStore.getState().setOne(store);
+
+      const result = calculateSiteBurn(siteId);
+
+      const ratBurn = result.burns.find((b) => b.materialTicker === 'RAT');
+      // Without the epsilon this would read 50 / 0.0005 = 100,000 days — a
+      // nonsense countdown. Balanced must classify as Infinity / ok.
+      expect(ratBurn?.daysRemaining).toBe(Infinity);
+      expect(ratBurn?.urgency).toBe('ok');
     });
 
     it('handles empty production queue (no contribution)', () => {

--- a/core/__tests__/prod.test.ts
+++ b/core/__tests__/prod.test.ts
@@ -75,6 +75,24 @@ describe('classifyProdStatus', () => {
     expect(classifyProdStatus([line])).toEqual({ tier: 'full', active: 2, capacity: 2 });
   });
 
+  it('caps per line, not globally: an over-capacity line cannot mask an idle line', () => {
+    // Line A: 1 building, 2 started orders (recurring queue overlap).
+    // Line B: 1 building, nothing running.
+    // Correct: min(2,1) + min(0,1) = 1 active of 2 → partial. A global
+    // min(totalRunning=2, totalCapacity=2) implementation would wrongly
+    // report 'full', letting line A's surplus orders hide line B's idle CapEx.
+    const overCapacity = createTestProductionLine({
+      capacity: 1,
+      orders: [runningOrder(), runningOrder()],
+    });
+    const idle = createTestProductionLine({ capacity: 1, orders: [] });
+    expect(classifyProdStatus([overCapacity, idle])).toEqual({
+      tier: 'partial',
+      active: 1,
+      capacity: 2,
+    });
+  });
+
   it('aggregates across lines: one full line plus one stopped line is partial', () => {
     const farm = createTestProductionLine({ capacity: 2, orders: [runningOrder(), runningOrder()] });
     const plant = createTestProductionLine({ capacity: 3, orders: [] });
@@ -137,6 +155,16 @@ describe('orderProgressPct', () => {
     expect(orderProgressPct(order, -500)).toBe(0); // skew below start
     expect(orderProgressPct(order, 5000)).toBe(100); // finished but not cleared
   });
+
+  it('is null when duration is null — no total to divide by', () => {
+    const order = createProductionOrder({ started: { timestamp: 0 }, duration: null });
+    expect(orderProgressPct(order, 1000)).toBeNull();
+  });
+
+  it('is null for a zero-millis duration — guards the divide, never NaN/Infinity', () => {
+    const order = createProductionOrder({ started: { timestamp: 0 }, duration: { millis: 0 } });
+    expect(orderProgressPct(order, 1000)).toBeNull();
+  });
 });
 
 describe('sortOrders', () => {
@@ -156,6 +184,23 @@ describe('sortOrders', () => {
     const sorted = sortOrders([queuedFirst, halted, runningLater, queuedSecond, runningSoon]);
 
     expect(sorted).toEqual([runningSoon, runningLater, queuedFirst, queuedSecond, halted]);
+  });
+
+  it('sorts a running order with no completion ETA after running orders with one', () => {
+    // A running order can briefly lack a completion timestamp; it must not
+    // jump to the top of the "soonest first" running group.
+    const runningNoEta = createProductionOrder({
+      started: { timestamp: 0 },
+      completion: null,
+    });
+    const runningWithEta = createProductionOrder({
+      started: { timestamp: 0 },
+      completion: { timestamp: 500 },
+    });
+
+    const sorted = sortOrders([runningNoEta, runningWithEta]);
+
+    expect(sorted).toEqual([runningWithEta, runningNoEta]);
   });
 
   it('does not mutate the input array', () => {

--- a/core/__tests__/repair.test.ts
+++ b/core/__tests__/repair.test.ts
@@ -4,6 +4,8 @@ import {
   getBuildingLastRepairTimestamp,
   classifyRepairUrgency,
   calculateSiteRepairStatus,
+  calculateAllRepairStatuses,
+  calculateSiteRepairBuildings,
 } from '../repair';
 import { useSitesStore } from '../../stores/entities/sites';
 import {
@@ -123,5 +125,125 @@ describe('calculateSiteRepairStatus', () => {
     const result = calculateSiteRepairStatus('nope');
     expect(result.oldestBuildingAgeDays).toBeNull();
     expect(result.oldestBuildingCondition).toBeNull();
+  });
+});
+
+describe('calculateAllRepairStatuses', () => {
+  beforeEach(() => {
+    useSitesStore.getState().clear();
+  });
+
+  it('returns one summary per site, each computed independently', () => {
+    const now = Date.now();
+    const siteA = createTestSite({
+      siteId: 'site-a',
+      platforms: [
+        // repaired 5 days ago
+        platformOfType('PRODUCTION', {
+          siteId: 'site-a',
+          lastRepair: { timestamp: now - 5 * MS_PER_DAY },
+          condition: 0.97,
+        }),
+      ],
+    });
+    const siteB = createTestSite({
+      siteId: 'site-b',
+      platforms: [
+        // never repaired, built 25 days ago
+        platformOfType('RESOURCES', {
+          siteId: 'site-b',
+          lastRepair: null,
+          creationTime: { timestamp: now - 25 * MS_PER_DAY },
+          condition: 0.85,
+        }),
+      ],
+    });
+    useSitesStore.getState().setAll([siteA, siteB]);
+
+    const results = calculateAllRepairStatuses();
+    expect(results).toHaveLength(2);
+
+    const a = results.find((r) => r.siteId === 'site-a');
+    const b = results.find((r) => r.siteId === 'site-b');
+    expect(a?.oldestBuildingAgeDays).toBeCloseTo(5, 0);
+    expect(a?.oldestBuildingCondition).toBe(0.97);
+    expect(b?.oldestBuildingAgeDays).toBeCloseTo(25, 0);
+    expect(b?.oldestBuildingCondition).toBe(0.85);
+  });
+});
+
+describe('calculateSiteRepairBuildings', () => {
+  beforeEach(() => {
+    useSitesStore.getState().clear();
+  });
+
+  it('lists only repairable buildings, oldest-since-repair first, with ticker and name', () => {
+    const now = Date.now();
+    const site = createTestSite({
+      siteId: 'site-detail',
+      platforms: [
+        // repaired 10 days ago — second-oldest repairable
+        createPlatform({
+          siteId: 'site-detail',
+          module: createPlatformModule({
+            type: 'PRODUCTION',
+            reactorTicker: 'SME',
+            reactorName: 'Smelter',
+          }),
+          lastRepair: { timestamp: now - 10 * MS_PER_DAY },
+          condition: 0.95,
+        }),
+        // never repaired, built 30 days ago — lastRepair null falls back to
+        // creationTime, making this the oldest
+        createPlatform({
+          siteId: 'site-detail',
+          module: createPlatformModule({
+            type: 'RESOURCES',
+            reactorTicker: 'EXT',
+            reactorName: 'Extractor',
+          }),
+          lastRepair: null,
+          creationTime: { timestamp: now - 30 * MS_PER_DAY },
+          condition: 0.8,
+        }),
+        // not repairable — must all be excluded even though they are older
+        platformOfType('CORE', {
+          siteId: 'site-detail',
+          lastRepair: null,
+          creationTime: { timestamp: now - 100 * MS_PER_DAY },
+        }),
+        platformOfType('HABITATION', {
+          siteId: 'site-detail',
+          lastRepair: null,
+          creationTime: { timestamp: now - 100 * MS_PER_DAY },
+        }),
+        platformOfType('STORAGE', {
+          siteId: 'site-detail',
+          lastRepair: null,
+          creationTime: { timestamp: now - 100 * MS_PER_DAY },
+        }),
+      ],
+    });
+    useSitesStore.getState().setAll([site]);
+
+    const rows = calculateSiteRepairBuildings('site-detail');
+
+    // Only PRODUCTION and RESOURCES survive the filter
+    expect(rows).toHaveLength(2);
+
+    // Oldest first: 30 days (never-repaired extractor) before 10 days (smelter)
+    expect(rows[0].ticker).toBe('EXT');
+    expect(rows[0].name).toBe('Extractor');
+    expect(rows[0].ageDays).toBeCloseTo(30, 0);
+    expect(rows[0].condition).toBe(0.8);
+
+    expect(rows[1].ticker).toBe('SME');
+    expect(rows[1].name).toBe('Smelter');
+    expect(rows[1].ageDays).toBeCloseTo(10, 0);
+    expect(rows[1].condition).toBe(0.95);
+  });
+
+  it('returns an empty list for an unknown site', () => {
+    expect(calculateSiteRepairBuildings('nope')).toEqual([]);
   });
 });

--- a/hooks/__tests__/useSiteStaleness.test.ts
+++ b/hooks/__tests__/useSiteStaleness.test.ts
@@ -23,7 +23,7 @@ describe('deriveStaleness', () => {
     expect(result.isStale).toBe(true);
   });
 
-  it('returns cache state with stale flag and text', () => {
+  it('returns cache state with stale flag and the exact display text', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-03-24T12:00:00Z'));
 
@@ -35,8 +35,9 @@ describe('deriveStaleness', () => {
 
     expect(result.isStale).toBe(true);
     expect(result.colorClass).toBe('text-apxm-text/50');
-    expect(result.text).toMatch(/^cached/);
-    expect(result.text).toContain('ago');
+    // Fake timers make this fully deterministic — pin the whole string so a
+    // mangled middle ("cached · NaN ago", wrong unit) can't slip through.
+    expect(result.text).toBe('cached · 1m ago');
   });
 
   it('returns FIO state with amber color', () => {
@@ -61,6 +62,12 @@ describe('deriveStaleness', () => {
     expect(result.text).toContain('ago');
   });
 
+  it('the staleness threshold is 5 hours — the requirement, not whatever the constant says', () => {
+    // Deriving the boundary from STALE_THRESHOLD_MS alone would pass even if
+    // the constant were fat-fingered to 5 minutes. Pin the value itself.
+    expect(STALE_THRESHOLD_MS).toBe(5 * 60 * 60 * 1000);
+  });
+
   it('returns stale websocket state after 5 hours', () => {
     const entry: SiteSourceEntry = {
       source: 'websocket',
@@ -72,16 +79,15 @@ describe('deriveStaleness', () => {
     expect(result.colorClass).toBe('text-apxm-text/40');
   });
 
-  it('returns independent results for different entries', () => {
-    const fioEntry: SiteSourceEntry = { source: 'fio', updatedAt: 1000 };
-    const wsEntry: SiteSourceEntry = { source: 'websocket', updatedAt: Date.now() };
+  it('exactly at the threshold is still fresh (source uses strict >)', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-24T12:00:00Z'));
 
-    const result1 = deriveStaleness(fioEntry);
-    const result2 = deriveStaleness(wsEntry);
+    const entry: SiteSourceEntry = {
+      source: 'websocket',
+      updatedAt: Date.now() - STALE_THRESHOLD_MS,
+    };
 
-    expect(result1.isStale).toBe(true);
-    expect(result1.colorClass).toBe('text-amber-600/70');
-    expect(result2.isStale).toBe(false);
-    expect(result2.colorClass).toBe('text-apxm-text/50');
+    expect(deriveStaleness(entry).isStale).toBe(false);
   });
 });

--- a/lib/__tests__/address.test.ts
+++ b/lib/__tests__/address.test.ts
@@ -70,11 +70,18 @@ describe('getEntityDisplayName', () => {
   });
 
   it('handles multi-letter planet suffix', () => {
+    // The whole suffix after the system naturalId survives the replace,
+    // not just a single letter.
     const address = makeAddress(
       system('Romulan', 'ZV-759'),
-      planet('ZV-759d', 'ZV-759d')
+      planet('ZV-759ab', 'ZV-759ab')
     );
-    expect(getEntityDisplayName(address)).toBe('Romulan d');
+    expect(getEntityDisplayName(address)).toBe('Romulan ab');
+  });
+
+  it('falls back to station name when naturalId is empty', () => {
+    const address = makeAddress(station('Hortus Station', ''));
+    expect(getEntityDisplayName(address)).toBe('Hortus Station');
   });
 });
 

--- a/lib/__tests__/format-time.test.ts
+++ b/lib/__tests__/format-time.test.ts
@@ -1,5 +1,49 @@
-import { describe, it, expect } from 'vitest';
-import { formatCountdown } from '../format-time';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { formatCountdown, formatRelativeTime } from '../format-time';
+
+describe('formatRelativeTime', () => {
+  // Staleness display primitive: single largest unit, floored.
+  // Boundaries per source: <1 minute → '<1m', <60 minutes → 'Nm',
+  // <24 hours → 'Nh', otherwise 'Nd'.
+  const NOW = 1_700_000_000_000;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reads "<1m" up to the minute boundary, then "1m"', () => {
+    expect(formatRelativeTime(NOW)).toBe('<1m'); // 0ms ago
+    expect(formatRelativeTime(NOW - 59_999)).toBe('<1m'); // 59.999s ago
+    expect(formatRelativeTime(NOW - 60_000)).toBe('1m'); // exactly 1 minute
+  });
+
+  it('shows floored minutes mid-range', () => {
+    expect(formatRelativeTime(NOW - 5 * 60_000)).toBe('5m');
+  });
+
+  it('rolls over from 59m to 1h at the hour boundary', () => {
+    expect(formatRelativeTime(NOW - 59 * 60_000)).toBe('59m');
+    expect(formatRelativeTime(NOW - 60 * 60_000)).toBe('1h'); // exactly 60 minutes
+  });
+
+  it('shows floored hours mid-range', () => {
+    expect(formatRelativeTime(NOW - 5 * 3_600_000)).toBe('5h');
+  });
+
+  it('rolls over from 23h to 1d at the day boundary', () => {
+    expect(formatRelativeTime(NOW - 23 * 3_600_000)).toBe('23h');
+    expect(formatRelativeTime(NOW - 24 * 3_600_000)).toBe('1d'); // exactly 24 hours
+  });
+
+  it('shows floored days mid-range', () => {
+    expect(formatRelativeTime(NOW - 3 * 86_400_000)).toBe('3d');
+  });
+});
 
 describe('formatCountdown', () => {
   it('shows two units, dropping the smallest once days appear', () => {

--- a/lib/__tests__/material-colors.test.ts
+++ b/lib/__tests__/material-colors.test.ts
@@ -16,6 +16,10 @@ describe('material-colors', () => {
       expect(normalizeCategory('AGRICULTURAL_PRODUCTS')).toBe('agricultural-products');
     });
 
+    it('strips parentheses — FIO CategoryName uses "consumables (basic)" format', () => {
+      expect(normalizeCategory('consumables (basic)')).toBe('consumables-basic');
+    });
+
     it('handles null/undefined', () => {
       expect(normalizeCategory(null)).toBe('default');
       expect(normalizeCategory(undefined)).toBe('default');

--- a/lib/debug/__tests__/logger.test.ts
+++ b/lib/debug/__tests__/logger.test.ts
@@ -13,6 +13,55 @@ function createMockMessage(overrides: Partial<ProcessedMessage> = {}): Processed
   };
 }
 
+describe('production suppression contract (__DEV__ false)', () => {
+  // Vitest realizes the define entry as a globalThis property, so stubbing
+  // the global exercises the production build's logging path.
+  let logSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.stubGlobal('__DEV__', false);
+    logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    window.history.replaceState(null, '', '/');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    logSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+    window.history.replaceState(null, '', '/');
+  });
+
+  it('log and warn are silent in production', () => {
+    log('should not appear');
+    warn('should not appear');
+    logMessage(createMockMessage());
+
+    expect(logSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('error stays active in production — failures must remain visible', () => {
+    error('a real failure');
+
+    expect(errorSpy).toHaveBeenCalledWith('[APXM]', 'a real failure');
+  });
+
+  it('?apxm_debug in the URL re-enables log/warn in production', () => {
+    window.history.replaceState(null, '', '/?apxm_debug');
+
+    log('debug session');
+    warn('debug session');
+
+    expect(logSpy).toHaveBeenCalledWith('[APXM]', 'debug session');
+    expect(warnSpy).toHaveBeenCalledWith('[APXM]', 'debug session');
+  });
+});
+
 describe('logMessage', () => {
   let logSpy: ReturnType<typeof vi.spyOn>;
 

--- a/lib/fio/__tests__/client.test.ts
+++ b/lib/fio/__tests__/client.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { fetchAllMaterials, fetchExchangeAll } from '../client';
+import { fetchAllMaterials, fetchExchangeAll, fetchStorage } from '../client';
+import type { FioConfig } from '../types';
 
 /**
  * The public-endpoint contract: correct paths, NO Authorization header
@@ -77,6 +78,100 @@ describe('FIO public client', () => {
     if (!result.ok) {
       expect(result.error.type).toBe('network');
       expect(result.error.message).toBe('connection refused');
+    }
+  });
+});
+
+/**
+ * The authenticated-endpoint contract: the API key travels as the
+ * Authorization header, the username is URL-encoded into the path, and
+ * HTTP failures map to the categorized error results the sync layer
+ * switches on (unauthorized/not_found), with 204 as a valid empty fetch.
+ */
+describe('FIO authenticated client', () => {
+  const fetchMock = vi.fn();
+  const config: FioConfig = { username: 'test user+1', apiKey: 'secret-key-123' };
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', fetchMock);
+    fetchMock.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function okResponse(data: unknown): Response {
+    return {
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(data),
+    } as unknown as Response;
+  }
+
+  it('sends the API key as the Authorization header', async () => {
+    fetchMock.mockResolvedValue(okResponse([]));
+
+    await fetchStorage(config);
+
+    const headers = fetchMock.mock.calls[0][1].headers;
+    expect(headers.Authorization).toBe('secret-key-123');
+  });
+
+  it('encodeURIComponent-encodes the username into the URL path', async () => {
+    fetchMock.mockResolvedValue(okResponse([]));
+
+    await fetchStorage(config);
+
+    // 'test user+1' → space %20, plus %2B — raw chars must not reach the URL.
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://rest.fnar.net/storage/test%20user%2B1',
+      expect.objectContaining({ method: 'GET' })
+    );
+  });
+
+  it('maps a 401 to the unauthorized error category', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: 'Unauthorized',
+    } as unknown as Response);
+
+    const result = await fetchStorage(config);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe('unauthorized');
+    }
+  });
+
+  it('maps a 404 to the not_found error category', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+    } as unknown as Response);
+
+    const result = await fetchStorage(config);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.type).toBe('not_found');
+    }
+  });
+
+  it('treats 204 No Content as success with an empty array (no json() call)', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 204,
+      json: () => Promise.reject(new Error('204 has no body')),
+    } as unknown as Response);
+
+    const result = await fetchStorage(config);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toEqual([]);
     }
   });
 });

--- a/lib/fio/__tests__/transforms.test.ts
+++ b/lib/fio/__tests__/transforms.test.ts
@@ -279,11 +279,17 @@ describe('FIO Transforms', () => {
     });
 
     it('maps storage types correctly', () => {
+      // All 8 FIO storage types known to mapStorageType — each passes
+      // through unchanged rather than falling back to STORE.
       const types = [
         'STORE',
         'SHIP_STORE',
+        'STL_FUEL_STORE',
+        'FTL_FUEL_STORE',
         'WAREHOUSE_STORE',
         'CONSTRUCTION_STORE',
+        'UPKEEP_STORE',
+        'VORTEX_FUEL_STORE',
       ] as const;
 
       for (const type of types) {
@@ -420,6 +426,64 @@ describe('FIO boundary validation', () => {
     // must be skipped without dropping the valid first record.
     const malformed = { SiteId: 'broken', PlanetId: 'p2' };
     const result = transformAllWorkforce([validWorkforce, malformed]);
+    expect(result).toHaveLength(1);
+    expect(result[0].siteId).toBe('site-1');
+  });
+
+  it('transformAllStorage skips a record missing StorageItems but keeps the valid one', () => {
+    const validStorage = {
+      StorageId: 'store-1',
+      AddressableId: 'site-1',
+      Name: 'Base Storage',
+      WeightLoad: 0,
+      WeightCapacity: 1000,
+      VolumeLoad: 0,
+      VolumeCapacity: 500,
+      StorageItems: [],
+      FixedStore: false,
+      Type: 'STORE',
+    };
+    // No StorageItems array → .map throws → record skipped, not fatal.
+    const malformed = { StorageId: 'broken' };
+    const result = transformAllStorage([validStorage, malformed]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('store-1');
+  });
+
+  it('transformAllProduction skips a record missing Orders but keeps the valid one', () => {
+    const validLine = {
+      ProductionLineId: 'line-1',
+      SiteId: 'site-1',
+      PlanetId: 'p1',
+      PlanetNaturalId: 'XY-123a',
+      PlanetName: 'Test',
+      Type: 'Farm',
+      Capacity: 1,
+      Efficiency: 1,
+      Condition: 1,
+      Orders: [],
+    };
+    // No Orders array → .map throws → record skipped, not fatal.
+    const malformed = { ProductionLineId: 'broken' };
+    const result = transformAllProduction([validLine, malformed]);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('line-1');
+  });
+
+  it('transformAllSites skips a record missing Buildings but keeps the valid one', () => {
+    const validSite = {
+      SiteId: 'site-1',
+      PlanetId: 'p1',
+      PlanetIdentifier: 'XY-123a',
+      PlanetName: 'Test',
+      PlanetFoundedEpochMs: 1704067200000,
+      InvestedPermits: 1,
+      MaximumPermits: 3,
+      Buildings: [],
+    };
+    // No Buildings array → .map throws → record skipped, not fatal.
+    const malformed = { SiteId: 'broken' };
+    const result = transformAllSites([validSite, malformed]);
     expect(result).toHaveLength(1);
     expect(result[0].siteId).toBe('site-1');
   });

--- a/stores/__tests__/connection.test.ts
+++ b/stores/__tests__/connection.test.ts
@@ -1,17 +1,16 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useConnectionStore } from '../connection';
 
+// Pristine state captured at import time, before any test touches the store.
+// beforeEach restores from this snapshot instead of hand-writing the expected
+// values — so the "initial state" tests assert the SOURCE defaults and fail
+// if one ever flips (e.g. connected: true). Safe to share: the store's
+// actions always replace unknownMessageTypes with a new array, never mutate.
+const pristineState = useConnectionStore.getState();
+
 describe('connection store', () => {
   beforeEach(() => {
-    useConnectionStore.setState({
-      connected: false,
-      lastMessageTimestamp: null,
-      messageCount: 0,
-      reconnectCount: 0,
-      discardedMessages: 0,
-      unknownMessageTypes: [],
-      apexUnresponsive: false,
-    });
+    useConnectionStore.setState(pristineState, true);
   });
 
   describe('initial state', () => {
@@ -41,6 +40,10 @@ describe('connection store', () => {
 
     it('starts with apexUnresponsive false', () => {
       expect(useConnectionStore.getState().apexUnresponsive).toBe(false);
+    });
+
+    it('starts with interceptorConflict false', () => {
+      expect(useConnectionStore.getState().interceptorConflict).toBe(false);
     });
   });
 
@@ -123,6 +126,24 @@ describe('connection store', () => {
 
       useConnectionStore.getState().setApexUnresponsive(false);
       expect(useConnectionStore.getState().apexUnresponsive).toBe(false);
+    });
+  });
+
+  describe('setInterceptorConflict', () => {
+    it('updates interceptorConflict state', () => {
+      useConnectionStore.getState().setInterceptorConflict(true);
+      expect(useConnectionStore.getState().interceptorConflict).toBe(true);
+
+      useConnectionStore.getState().setInterceptorConflict(false);
+      expect(useConnectionStore.getState().interceptorConflict).toBe(false);
+    });
+
+    it('is restored to false by reset', () => {
+      useConnectionStore.getState().setInterceptorConflict(true);
+
+      useConnectionStore.getState().reset();
+
+      expect(useConnectionStore.getState().interceptorConflict).toBe(false);
     });
   });
 

--- a/stores/__tests__/create-entity-store.test.ts
+++ b/stores/__tests__/create-entity-store.test.ts
@@ -1,4 +1,38 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { BUILD_VERSION } from '../../lib/constants';
+
+// In-memory stand-in for browser.storage.local so the persistence path is
+// exercised for real (what gets written/read), not stubbed out. vi.hoisted
+// because vi.mock factories run before module-scope const declarations.
+const storageMock = vi.hoisted(() => {
+  const data = new Map<string, string>();
+  return {
+    data,
+    get: vi.fn(async (key: string) => {
+      const value = data.get(key);
+      return value === undefined ? {} : { [key]: value };
+    }),
+    set: vi.fn(async (items: Record<string, string>) => {
+      for (const [key, value] of Object.entries(items)) data.set(key, value);
+    }),
+    remove: vi.fn(async (key: string) => {
+      data.delete(key);
+    }),
+  };
+});
+
+vi.mock('wxt/browser', () => ({
+  browser: {
+    storage: {
+      local: {
+        get: storageMock.get,
+        set: storageMock.set,
+        remove: storageMock.remove,
+      },
+    },
+  },
+}));
+
 import { createEntityStore } from '../create-entity-store';
 
 interface TestEntity {
@@ -328,6 +362,148 @@ describe('createEntityStore', () => {
 
       expect(store.getState().fetched).toBe(true);
       expect(store.getState().dataSource).toBe('websocket');
+    });
+  });
+
+  describe('invalid entity ids', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('setAll skips entities with empty or missing ids and keeps valid ones', () => {
+      store.getState().setAll([
+        { id: '1', name: 'valid', value: 1 },
+        { id: '', name: 'empty-id', value: 2 },
+        { name: 'missing-id', value: 3 } as unknown as TestEntity,
+      ]);
+
+      expect(store.getState().entities.size).toBe(1);
+      expect(store.getState().getById('1')?.name).toBe('valid');
+    });
+
+    it('setMany skips entities with empty or missing ids and keeps valid ones', () => {
+      store.getState().setMany([
+        { id: '', name: 'empty-id', value: 1 },
+        { id: '2', name: 'valid', value: 2 },
+        { name: 'missing-id', value: 3 } as unknown as TestEntity,
+      ]);
+
+      expect(store.getState().entities.size).toBe(1);
+      expect(store.getState().getById('2')?.name).toBe('valid');
+    });
+  });
+
+  describe('persistence', () => {
+    // Hand-derived: source debounces saves by 2s, TTL default is 24h.
+    const DEBOUNCE_MS = 2000;
+    const HOUR_MS = 60 * 60 * 1000;
+
+    function makeCacheEntry(cachedAt: number, version = BUILD_VERSION): string {
+      return JSON.stringify({
+        entities: { e1: { id: 'e1', name: 'cached', value: 42 } },
+        lastUpdated: cachedAt,
+        dataSource: 'websocket',
+        cachedAt,
+        version,
+      });
+    }
+
+    beforeEach(() => {
+      storageMock.data.clear();
+      storageMock.get.mockClear();
+      storageMock.set.mockClear();
+      storageMock.remove.mockClear();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('debounces rapid mutations into a single storage write after 2s', async () => {
+      vi.useFakeTimers();
+      const pstore = createEntityStore<TestEntity>('p-debounce', (i) => i.id, {
+        key: 'cache-debounce',
+      });
+      pstore.getState().setFetched('websocket');
+
+      pstore.getState().setOne({ id: '1', name: 'one', value: 1 });
+      pstore.getState().setOne({ id: '2', name: 'two', value: 2 });
+
+      // Nothing written yet — the save is debounced
+      expect(storageMock.set).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(DEBOUNCE_MS);
+
+      // One write for the burst, carrying both entities and the build version
+      expect(storageMock.set).toHaveBeenCalledTimes(1);
+      const written = JSON.parse(storageMock.data.get('cache-debounce')!);
+      expect(Object.keys(written.entities).sort()).toEqual(['1', '2']);
+      expect(written.dataSource).toBe('websocket');
+      expect(written.version).toBe(BUILD_VERSION);
+    });
+
+    it('rehydrate restores fresh cache and marks dataSource as cache', async () => {
+      // 1 hour old — well within the 24h TTL
+      storageMock.data.set('cache-fresh', makeCacheEntry(Date.now() - HOUR_MS));
+      const pstore = createEntityStore<TestEntity>('p-fresh', (i) => i.id, {
+        key: 'cache-fresh',
+      });
+
+      await expect(pstore.rehydrate()).resolves.toBe(true);
+
+      expect(pstore.getState().getById('e1')?.name).toBe('cached');
+      expect(pstore.getState().fetched).toBe(true);
+      // Rehydrated data must be flagged cache so staleness UI can degrade it
+      expect(pstore.getState().dataSource).toBe('cache');
+    });
+
+    it('rehydrate discards cache older than the 24h TTL', async () => {
+      // 25 hours old — one hour past the TTL
+      storageMock.data.set('cache-stale', makeCacheEntry(Date.now() - 25 * HOUR_MS));
+      const pstore = createEntityStore<TestEntity>('p-stale', (i) => i.id, {
+        key: 'cache-stale',
+      });
+
+      await expect(pstore.rehydrate()).resolves.toBe(false);
+
+      expect(pstore.getState().entities.size).toBe(0);
+      expect(pstore.getState().fetched).toBe(false);
+      expect(pstore.getState().dataSource).toBeNull();
+    });
+
+    it('rehydrate discards cache from a different build version', async () => {
+      storageMock.data.set(
+        'cache-version',
+        makeCacheEntry(Date.now() - HOUR_MS, 'v0.0.0-other')
+      );
+      const pstore = createEntityStore<TestEntity>('p-version', (i) => i.id, {
+        key: 'cache-version',
+      });
+
+      await expect(pstore.rehydrate()).resolves.toBe(false);
+
+      expect(pstore.getState().entities.size).toBe(0);
+      expect(pstore.getState().dataSource).toBeNull();
+    });
+
+    it('clear() removes the cache key from storage', async () => {
+      storageMock.data.set('cache-clear', makeCacheEntry(Date.now()));
+      const pstore = createEntityStore<TestEntity>('p-clear', (i) => i.id, {
+        key: 'cache-clear',
+      });
+
+      pstore.getState().clear();
+
+      expect(storageMock.remove).toHaveBeenCalledWith('cache-clear');
+      // The remove is fire-and-forget — let the mock's promise settle
+      await Promise.resolve();
+      expect(storageMock.data.has('cache-clear')).toBe(false);
     });
   });
 });

--- a/stores/__tests__/gameState.test.ts
+++ b/stores/__tests__/gameState.test.ts
@@ -1,26 +1,21 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import {
-  useGameState,
-  type BurnFilter,
-  type FleetFilter,
-  type ContractFilter,
-} from '../gameState';
+import { useGameState, type BurnFilter } from '../gameState';
 
 /**
  * gameState store tests.
  * Note: Connection state (connected, lastMessageTimestamp, messageCount)
  * has been moved to stores/connection.ts as of Chunk 2.
  */
+// Pristine state captured at import time, before any test touches the store.
+// beforeEach restores from this snapshot instead of hand-writing the expected
+// values — so the "initial state" tests assert the SOURCE defaults and fail
+// if one ever flips. Safe to share: the filter toggles always build new Sets,
+// never mutate the ones in state.
+const pristineState = useGameState.getState();
+
 describe('gameState store', () => {
   beforeEach(() => {
-    // Reset store to initial state
-    useGameState.setState({
-      overlayVisible: true,
-      debugMode: false,
-      burnFilters: new Set<BurnFilter>(['all']),
-      fleetFilters: new Set<FleetFilter>(['all']),
-      contractFilters: new Set<ContractFilter>(['active']),
-    });
+    useGameState.setState(pristineState, true);
   });
 
   describe('initial state', () => {
@@ -30,6 +25,18 @@ describe('gameState store', () => {
 
     it('debug mode is off by default', () => {
       expect(useGameState.getState().debugMode).toBe(false);
+    });
+
+    it('APEX is hidden by default — the overlay covers it', () => {
+      expect(useGameState.getState().apexVisible).toBe(false);
+    });
+
+    it('starts on the status tab', () => {
+      expect(useGameState.getState().activeTab).toBe('status');
+    });
+
+    it('starts with no drill-down sheet open', () => {
+      expect(useGameState.getState().detailView).toBeNull();
     });
   });
 
@@ -44,6 +51,54 @@ describe('gameState store', () => {
     it('updates debug mode', () => {
       useGameState.getState().setDebugMode(true);
       expect(useGameState.getState().debugMode).toBe(true);
+    });
+  });
+
+  describe('setApexVisible', () => {
+    it('toggles APEX visibility', () => {
+      useGameState.getState().setApexVisible(true);
+      expect(useGameState.getState().apexVisible).toBe(true);
+
+      useGameState.getState().setApexVisible(false);
+      expect(useGameState.getState().apexVisible).toBe(false);
+    });
+  });
+
+  describe('setActiveTab', () => {
+    it('switches the active tab', () => {
+      useGameState.getState().setActiveTab('fleet');
+      expect(useGameState.getState().activeTab).toBe('fleet');
+
+      useGameState.getState().setActiveTab('bases');
+      expect(useGameState.getState().activeTab).toBe('bases');
+    });
+  });
+
+  describe('setDetailView', () => {
+    it('opens a site drill-down sheet with the full payload', () => {
+      useGameState.getState().setDetailView({
+        type: 'burn',
+        siteId: 'site-1',
+        siteName: 'Montem Base',
+      });
+
+      expect(useGameState.getState().detailView).toEqual({
+        type: 'burn',
+        siteId: 'site-1',
+        siteName: 'Montem Base',
+      });
+    });
+
+    it('closes the sheet when set to null', () => {
+      useGameState.getState().setDetailView({
+        type: 'production',
+        siteId: 'site-1',
+        siteName: 'Montem Base',
+      });
+
+      useGameState.getState().setDetailView(null);
+
+      expect(useGameState.getState().detailView).toBeNull();
     });
   });
 

--- a/stores/__tests__/message-handlers.test.ts
+++ b/stores/__tests__/message-handlers.test.ts
@@ -96,6 +96,18 @@ describe('message-handlers', () => {
     });
   });
 
+  describe('unregistered message types', () => {
+    it('records unhandled types via addUnknownMessageType', () => {
+      dispatchMessage('SOME_UNHANDLED_TYPE', {});
+
+      expect(useConnectionStore.getState().unknownMessageTypes).toContain(
+        'SOME_UNHANDLED_TYPE'
+      );
+      // Unknown ≠ malformed: an unhandled type is a blind spot, not a discard
+      expect(useConnectionStore.getState().discardedMessages).toBe(0);
+    });
+  });
+
   describe('CLIENT_CONNECTION_OPENED', () => {
     // Populate the three ACT-engine stores (not covered by clearAllEntityStores).
     function populateActStores(): void {
@@ -647,6 +659,27 @@ describe('message-handlers', () => {
         'SITE_SITE: unexpected payload structure',
         expect.anything()
       );
+
+      warnSpy.mockRestore();
+    });
+
+    it('malformed SITE_SITES warns but does NOT increment discardedMessages', () => {
+      // Pins the bulk-handler contract: bulk handlers (SITE_SITES et al.)
+      // only warn on a malformed payload, unlike the singular handlers
+      // (SITE_SITE does incrementDiscarded). This asymmetry is current
+      // intended behavior — visibility comes from the warn. A change to
+      // either side of it should be deliberate, not accidental.
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      dispatchMessage('SITE_SITES', { notSites: true });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[APXM]',
+        'SITE_SITES: unexpected payload structure',
+        expect.anything()
+      );
+      expect(useConnectionStore.getState().discardedMessages).toBe(0);
+      expect(useSitesStore.getState().entities.size).toBe(0);
 
       warnSpy.mockRestore();
     });

--- a/stores/__tests__/site-data-sources.test.ts
+++ b/stores/__tests__/site-data-sources.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { useSiteSourceStore } from '../site-data-sources';
+import {
+  useSiteSourceStore,
+  deriveWeakestSource,
+  deriveOldestUpdate,
+  type SiteSourceEntry,
+} from '../site-data-sources';
 
 describe('site-data-sources store', () => {
   beforeEach(() => {
@@ -70,5 +75,58 @@ describe('site-data-sources store', () => {
 
       expect(useSiteSourceStore.getState().entries.size).toBe(0);
     });
+  });
+});
+
+// Helper to build the Map shape the derive functions consume.
+function entriesMap(
+  ...list: Array<[string, SiteSourceEntry]>
+): Map<string, SiteSourceEntry> {
+  return new Map(list);
+}
+
+describe('deriveWeakestSource', () => {
+  it('returns null for an empty map', () => {
+    expect(deriveWeakestSource(entriesMap())).toBeNull();
+  });
+
+  it('all-websocket yields websocket', () => {
+    const entries = entriesMap(
+      ['site-1', { source: 'websocket', updatedAt: 1000 }],
+      ['site-2', { source: 'websocket', updatedAt: 2000 }]
+    );
+    expect(deriveWeakestSource(entries)).toBe('websocket');
+  });
+
+  it('fio beats websocket — mixed fio+websocket yields fio', () => {
+    const entries = entriesMap(
+      ['site-1', { source: 'websocket', updatedAt: 1000 }],
+      ['site-2', { source: 'fio', updatedAt: 2000 }]
+    );
+    expect(deriveWeakestSource(entries)).toBe('fio');
+  });
+
+  it('cache beats everything — a mixed map yields cache', () => {
+    const entries = entriesMap(
+      ['site-1', { source: 'websocket', updatedAt: 1000 }],
+      ['site-2', { source: 'fio', updatedAt: 2000 }],
+      ['site-3', { source: 'cache', updatedAt: 3000 }]
+    );
+    expect(deriveWeakestSource(entries)).toBe('cache');
+  });
+});
+
+describe('deriveOldestUpdate', () => {
+  it('returns null for an empty map', () => {
+    expect(deriveOldestUpdate(entriesMap())).toBeNull();
+  });
+
+  it('returns the oldest timestamp across all sites', () => {
+    const entries = entriesMap(
+      ['site-1', { source: 'websocket', updatedAt: 5000 }],
+      ['site-2', { source: 'fio', updatedAt: 1000 }],
+      ['site-3', { source: 'websocket', updatedAt: 3000 }]
+    );
+    expect(deriveOldestUpdate(entries)).toBe(1000);
   });
 });

--- a/stores/__tests__/warehouses.test.ts
+++ b/stores/__tests__/warehouses.test.ts
@@ -28,6 +28,28 @@ describe('warehouse store', () => {
     expect(useWarehouseStore.getState().getByEntityNaturalId('UNKNOWN')).toBeUndefined();
   });
 
+  it('getBySystem finds a warehouse by systemNaturalId', () => {
+    useWarehouseStore.getState().setWarehouses([
+      { warehouseId: 'w1', storeId: 's1', systemNaturalId: 'CI', stationNaturalId: 'CI1' },
+      { warehouseId: 'w2', storeId: 's2', systemNaturalId: 'NC', stationNaturalId: 'NC1' },
+    ]);
+
+    expect(useWarehouseStore.getState().getBySystem('NC')?.warehouseId).toBe('w2');
+    expect(useWarehouseStore.getState().getBySystem('ZZ')).toBeUndefined();
+  });
+
+  it('station match wins over system match for the same naturalId', () => {
+    // The system-matching warehouse is listed FIRST: a naive first-match-in-
+    // list lookup would return it. The contract is station-before-system,
+    // because an exchange code is a station naturalId.
+    useWarehouseStore.getState().setWarehouses([
+      { warehouseId: 'wB', storeId: 'sB', systemNaturalId: 'X', stationNaturalId: null },
+      { warehouseId: 'wA', storeId: 'sA', systemNaturalId: 'OTHER', stationNaturalId: 'X' },
+    ]);
+
+    expect(useWarehouseStore.getState().getByEntityNaturalId('X')?.warehouseId).toBe('wA');
+  });
+
   it('addWarehouse replaces an existing entry with the same warehouseId', () => {
     const store = useWarehouseStore.getState();
     store.addWarehouse({ warehouseId: 'w1', storeId: 's1', systemNaturalId: 'CI', stationNaturalId: 'CI1' });

--- a/types/__tests__/prun-api.test.ts
+++ b/types/__tests__/prun-api.test.ts
@@ -14,19 +14,31 @@ import {
 } from '../../__tests__/fixtures/factories';
 
 /**
- * Type parsing tests verify that our PrunApi types correctly match
- * the expected wire format from the game server.
+ * What this file does and does NOT guard — be honest about the contract:
  *
- * These tests construct objects matching the wire protocol and verify
- * they satisfy our TypeScript interfaces without runtime errors.
+ * - It does NOT verify the types match the game server's wire format. Types
+ *   are erased at runtime, and no captured wire data is checked here. If the
+ *   server's format drifts, nothing in this repo turns red automatically;
+ *   the diagnostics overlay's unknown-message tracking and manual testing
+ *   are the actual detection paths.
+ * - The typed literals below ARE checked — at compile time, by the
+ *   `npx tsc --noEmit` gate (the vitest run itself strips types unchecked;
+ *   see the CLAUDE.md typecheck gotcha). They pin that our own type
+ *   definitions stay assignable from realistically-shaped objects, so a
+ *   type edit that breaks an established shape fails the typecheck.
+ * - The factory assertions guard the shared test fixtures: every suite in
+ *   the repo builds its inputs from these factories, so a factory that
+ *   silently stopped producing platforms/segments/conditions would weaken
+ *   many tests at once. Assertions here pin the structural invariants the
+ *   other suites rely on.
  */
-describe('PrunApi type definitions', () => {
+describe('PrunApi types and fixture factories', () => {
   beforeEach(() => {
     resetIdCounter();
   });
 
-  describe('Material', () => {
-    it('matches expected wire format', () => {
+  describe('compile-time wire-shape literals (checked by tsc, not vitest)', () => {
+    it('representative entity shapes stay assignable', () => {
       const material: PrunApi.Material = {
         id: 'mat-123',
         name: 'Basic Rations',
@@ -37,71 +49,21 @@ describe('PrunApi type definitions', () => {
         resource: false,
       };
 
-      expect(material.ticker).toBe('RAT');
-      expect(material.resource).toBe(false);
-    });
-
-    it('factory produces valid Material', () => {
-      const material = createMaterial();
-
-      expect(material.id).toBeDefined();
-      expect(material.ticker).toBeDefined();
-      expect(typeof material.weight).toBe('number');
-    });
-  });
-
-  describe('Address', () => {
-    it('parses system address line', () => {
       const address: PrunApi.Address = {
         lines: [
+          { type: 'SYSTEM', entity: { id: 'sys-1', naturalId: 'ZV-307', name: 'Moria' } },
           {
-            type: 'SYSTEM',
-            entity: {
-              id: 'sys-1',
-              naturalId: 'MORIA',
-              name: 'Moria',
-            },
-          },
+            type: 'PLANET',
+            entity: { id: 'pl-1', naturalId: 'ZV-307b', name: 'Metis b' },
+            orbit: null,
+          } as unknown as PrunApi.AddressLine,
         ],
       };
 
-      expect(address.lines[0].type).toBe('SYSTEM');
-      expect((address.lines[0] as PrunApi.SystemAddressLine).entity.naturalId).toBe('MORIA');
-    });
-
-    it('parses orbit address line', () => {
-      const address: PrunApi.Address = {
-        lines: [
-          {
-            type: 'ORBIT',
-            orbit: {
-              semiMajorAxis: 1.5,
-              eccentricity: 0.1,
-              inclination: 5,
-              rightAscension: 30,
-              periapsis: 45,
-            },
-          },
-        ],
-      };
-
-      expect(address.lines[0].type).toBe('ORBIT');
-      expect((address.lines[0] as PrunApi.OrbitAddressLine).orbit.semiMajorAxis).toBe(1.5);
-    });
-
-    it('factory produces valid Address', () => {
-      const address = createAddress();
-
-      expect(address.lines.length).toBeGreaterThan(0);
-    });
-  });
-
-  describe('Site', () => {
-    it('matches expected wire format', () => {
       const site: PrunApi.Site = {
         siteId: 'site-123',
-        address: createAddress(),
-        founded: { timestamp: Date.now() },
+        address,
+        founded: { timestamp: 1700000000000 },
         platforms: [],
         buildOptions: { options: [] },
         area: 500,
@@ -109,29 +71,14 @@ describe('PrunApi type definitions', () => {
         maximumPermits: 10,
       };
 
-      expect(site.siteId).toBe('site-123');
-      expect(site.buildOptions.options).toEqual([]);
-    });
-
-    it('factory produces valid Site with platforms', () => {
-      const site = createTestSite();
-
-      expect(site.siteId).toBeDefined();
-      expect(site.platforms.length).toBeGreaterThan(0);
-      expect(site.platforms[0].module.reactorTicker).toBeDefined();
-    });
-  });
-
-  describe('Store', () => {
-    it('matches expected wire format', () => {
       const store: PrunApi.Store = {
-        id: 'store-123',
+        id: 'store-1',
         addressableId: 'site-123',
         name: null,
-        weightLoad: 1000,
-        weightCapacity: 5000,
-        volumeLoad: 500,
-        volumeCapacity: 2500,
+        weightLoad: 10,
+        weightCapacity: 500,
+        volumeLoad: 8,
+        volumeCapacity: 500,
         items: [],
         fixed: true,
         tradeStore: false,
@@ -140,257 +87,78 @@ describe('PrunApi type definitions', () => {
         type: 'STORE',
       };
 
-      expect(store.type).toBe('STORE');
-      expect(store.name).toBeNull();
-    });
-
-    it('handles ship fuel store types', () => {
-      const stlStore = createTestStorage({ type: 'STL_FUEL_STORE' });
-      const ftlStore = createTestStorage({ type: 'FTL_FUEL_STORE' });
-
-      expect(stlStore.type).toBe('STL_FUEL_STORE');
-      expect(ftlStore.type).toBe('FTL_FUEL_STORE');
+      // Touch the values so the literals aren't dead code; the real check is
+      // that the annotations above compile.
+      expect([material.ticker, site.siteId, store.type, address.lines.length]).toEqual([
+        'RAT',
+        'site-123',
+        'STORE',
+        2,
+      ]);
     });
   });
 
-  describe('Workforce', () => {
-    it('matches expected wire format', () => {
-      const workforce: PrunApi.Workforce = {
-        level: 'PIONEER',
-        population: 100,
-        reserve: 10,
-        capacity: 100,
-        required: 100,
-        satisfaction: 0.85,
-        needs: [
-          {
-            category: 'FOOD',
-            essential: true,
-            material: createMaterial({ ticker: 'RAT' }),
-            satisfaction: 0.9,
-            unitsPerInterval: 4,
-            unitsPer100: 4,
-          },
-        ],
-      };
-
-      expect(workforce.level).toBe('PIONEER');
-      expect(workforce.needs[0].category).toBe('FOOD');
+  describe('fixture factory invariants (what the other suites rely on)', () => {
+    it('createMaterial produces a complete material with physical properties', () => {
+      const material = createMaterial();
+      expect(material.id).not.toBe('');
+      expect(material.ticker).not.toBe('');
+      expect(material.weight).toBeGreaterThan(0);
+      expect(material.volume).toBeGreaterThan(0);
     });
 
-    it('factory produces valid WorkforceEntity', () => {
-      const entity = createTestWorkforce();
-
-      expect(entity.siteId).toBeDefined();
-      expect(entity.workforces.length).toBeGreaterThan(0);
-      expect(entity.workforces[0].needs.length).toBeGreaterThan(0);
-    });
-  });
-
-  describe('ProductionLine', () => {
-    it('matches expected wire format with orders', () => {
-      const line: PrunApi.ProductionLine = {
-        id: 'prod-123',
-        siteId: 'site-123',
-        address: createAddress(),
-        type: 'FRM',
-        capacity: 2,
-        slots: 5,
-        efficiency: 0.95,
-        condition: 0.9,
-        workforces: [{ level: 'PIONEER', efficiency: 1.0 }],
-        orders: [],
-        productionTemplates: [],
-        efficiencyFactors: [],
-      };
-
-      expect(line.type).toBe('FRM');
-      expect(line.capacity).toBe(2);
+    it('createAddress produces resolvable lines (address display code depends on this)', () => {
+      const address = createAddress();
+      expect(address.lines.length).toBeGreaterThan(0);
+      for (const line of address.lines) {
+        expect(line.entity).toBeDefined();
+        expect(line.entity?.naturalId).not.toBe('');
+      }
     });
 
-    it('factory produces valid ProductionLine', () => {
+    it('createTestSite produces platforms with reactor modules (repair engine depends on this)', () => {
+      const site = createTestSite();
+      expect(site.platforms.length).toBeGreaterThan(0);
+      expect(site.platforms[0].module.reactorTicker).not.toBe('');
+      expect(site.platforms[0].module.reactorName).not.toBe('');
+    });
+
+    it('createTestStorage defaults to the STORE type (burn engine counts only STORE)', () => {
+      expect(createTestStorage().type).toBe('STORE');
+    });
+
+    it('createTestWorkforce carries needs (burn workforce consumption depends on this)', () => {
+      const wf = createTestWorkforce();
+      expect(wf.workforces.length).toBeGreaterThan(0);
+      expect(wf.workforces[0].needs.length).toBeGreaterThan(0);
+    });
+
+    it('createTestProductionLine carries typed orders', () => {
       const line = createTestProductionLine();
-
-      expect(line.id).toBeDefined();
-      expect(line.productionTemplates.length).toBeGreaterThan(0);
-    });
-  });
-
-  describe('Ship', () => {
-    it('matches expected wire format', () => {
-      const ship: PrunApi.Ship = {
-        id: 'ship-123',
-        idShipStore: 'store-1',
-        idStlFuelStore: 'store-2',
-        idFtlFuelStore: 'store-3',
-        registration: 'ABC-1234',
-        name: 'Cargo Hauler',
-        commissioningTime: { timestamp: Date.now() },
-        blueprintNaturalId: 'CARGO_BASIC',
-        address: null,
-        flightId: 'flight-1',
-        acceleration: 9.8,
-        thrust: 10000,
-        mass: 50000,
-        operatingEmptyMass: 45000,
-        volume: 500,
-        reactorPower: 100,
-        emitterPower: 100,
-        stlFuelStoreId: 'store-2',
-        stlFuelFlowRate: 0.5,
-        ftlFuelStoreId: 'store-3',
-        operatingTimeStl: { millis: 86400000 },
-        operatingTimeFtl: { millis: 43200000 },
-        condition: 0.9,
-        lastRepair: null,
-        repairMaterials: [],
-        status: 'STATIONARY',
-      };
-
-      expect(ship.flightId).toBe('flight-1');
-      expect(ship.address).toBeNull();
+      expect(line.capacity).toBeGreaterThan(0);
+      expect(Array.isArray(line.orders)).toBe(true);
     });
 
-    it('factory produces valid Ship', () => {
+    it('createTestShip and createTestFlight produce linked, segmented flight data', () => {
       const ship = createTestShip();
-
-      expect(ship.id).toBeDefined();
-      expect(ship.stlFuelFlowRate).toBeGreaterThan(0);
-    });
-  });
-
-  describe('Flight', () => {
-    it('matches expected wire format with segments', () => {
-      const flight: PrunApi.Flight = {
-        id: 'flight-123',
-        shipId: 'ship-123',
-        origin: createAddress({ planetName: 'Montem' }),
-        destination: createAddress({ planetName: 'Promitor' }),
-        departure: { timestamp: Date.now() },
-        arrival: { timestamp: Date.now() + 7200000 },
-        segments: [
-          {
-            type: 'TAKE_OFF',
-            origin: createAddress(),
-            departure: { timestamp: Date.now() },
-            destination: createAddress(),
-            arrival: { timestamp: Date.now() + 600000 },
-            stlDistance: 100,
-            stlFuelConsumption: 5,
-            transferEllipse: null,
-            ftlDistance: null,
-            ftlFuelConsumption: null,
-            damage: 0,
-          },
-        ],
-        currentSegmentIndex: 0,
-        stlDistance: 5000,
-        ftlDistance: 0,
-        aborted: false,
-      };
-
-      expect(flight.segments[0].type).toBe('TAKE_OFF');
-      expect(flight.aborted).toBe(false);
-    });
-
-    it('factory produces valid Flight with segments', () => {
       const flight = createTestFlight();
-
-      expect(flight.id).toBeDefined();
+      expect(ship.id).not.toBe('');
       expect(flight.segments.length).toBeGreaterThan(0);
     });
-  });
 
-  describe('Contract', () => {
-    it('matches expected wire format with conditions', () => {
-      const contract: PrunApi.Contract = {
-        id: 'contract-123',
-        localId: 'CT-001',
-        date: { timestamp: Date.now() },
-        party: 'PROVIDER',
-        partner: {
-          id: 'partner-123',
-          name: 'Trade Corp',
-          code: 'TC',
-        },
-        status: 'OPEN',
-        conditions: [
-          {
-            type: 'DELIVERY',
-            id: 'cond-1',
-            party: 'PROVIDER',
-            index: 0,
-            status: 'PENDING',
-            dependencies: [],
-            deadlineDuration: { millis: 259200000 },
-            deadline: { timestamp: Date.now() + 259200000 },
-          },
-        ],
-        extensionDeadline: null,
-        canExtend: false,
-        canRequestTermination: true,
-        dueDate: { timestamp: Date.now() + 604800000 },
-        name: 'Delivery Contract',
-        preamble: null,
-        terminationSent: false,
-        terminationReceived: false,
-        agentContract: false,
-        relatedContracts: [],
-        contractType: null,
-      };
-
-      expect(contract.status).toBe('OPEN');
-      expect(contract.conditions[0].type).toBe('DELIVERY');
-    });
-
-    it('factory produces valid Contract', () => {
+    it('createTestContract produces conditions with ids (dependency logic depends on this)', () => {
       const contract = createTestContract();
-
-      expect(contract.id).toBeDefined();
       expect(contract.conditions.length).toBeGreaterThan(0);
-    });
-  });
-
-  describe('Contract condition types', () => {
-    it('handles DELIVERY condition', () => {
-      const condition: PrunApi.ContractCondition = {
-        type: 'DELIVERY',
-        id: 'cond-1',
-        party: 'PROVIDER',
-        index: 0,
-        status: 'PENDING',
-        dependencies: [],
-        deadlineDuration: null,
-        deadline: null,
-        quantity: {
-          material: createMaterial(),
-          amount: 100,
-        },
-        address: createAddress(),
-      };
-
-      expect(condition.type).toBe('DELIVERY');
-      expect(condition.quantity?.amount).toBe(100);
+      for (const cond of contract.conditions) {
+        expect(cond.id).not.toBe('');
+      }
     });
 
-    it('handles PAYMENT condition', () => {
-      const condition: PrunApi.ContractCondition = {
-        type: 'PAYMENT',
-        id: 'cond-1',
-        party: 'CUSTOMER',
-        index: 0,
-        status: 'PENDING',
-        dependencies: [],
-        deadlineDuration: null,
-        deadline: null,
-        amount: {
-          currency: 'AIC',
-          amount: 50000,
-        },
-      };
-
-      expect(condition.type).toBe('PAYMENT');
-      expect(condition.amount?.amount).toBe(50000);
+    it('resetIdCounter makes factory ids deterministic across tests', () => {
+      const first = createTestSite().siteId;
+      resetIdCounter();
+      const second = createTestSite().siteId;
+      expect(second).toBe(first);
     });
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,10 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   define: {
+    // Vitest realizes define entries as globalThis properties, so source
+    // references to the bare __DEV__ identifier resolve through globalThis —
+    // tests can exercise the production path with vi.stubGlobal('__DEV__', false)
+    // (see logger.test.ts's suppression suite).
     __DEV__: 'true',
   },
   test: {


### PR DESCRIPTION
Follow-up to the four-way test-quality audit. Stacked on #66 (base = `feat/act-foundations`); merge #66 first and this retargets to main automatically when the branch is deleted.

## Source fix
- `reconcileOrder` now dedupes a corrupted saved panel order — a repeated id previously rendered the same Status panel twice (duplicate React keys). Regression test added.

## Suite integrity
- **prun-api.test.ts rewritten honestly** — it claimed to guard the wire format but couldn't (types erased at runtime; vitest strips types unchecked). Now: compile-time shape literals checked by the `tsc` gate + fixture-factory invariants, with the real contract documented in the header.
- **Tautological initial-state tests fixed** (connection/gameState): beforeEach restores a pristine import-time snapshot, so a flipped source default now fails the suite.
- **Logger's production-suppression contract now testable** via `vi.stubGlobal('__DEV__', false)`.

## New coverage highlights
- The v1.0.0 **per-building repair gauge** engine (had zero tests)
- **Entity-store persistence**: debounce, 24h TTL, version mismatch, rehydrate→'cache', invalid-id skips
- Site-level burn epsilon (independent of the empire path, #31-proofing); per-line PROD capping; `formatRelativeTime` boundaries; FIO authenticated client path; `assembleContractDetails` extracted pure + ACTIVE-includes-OPEN pinned; DataGate ready-beats-unresponsive; ~15 more

## Verification
- Typecheck clean; tests **471 → 520**; both builds green
- Five guards mutation-verified (bug reintroduced → test fails → restored → green): repair type filter, persistence TTL, hour rollover, reconnect-clear, warehouse precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)