### PR TITLE
feat(act): port the ACT engine from jackinabox86's fork (#25 Phase C)

### DIFF
--- a/lib/act/__tests__/bills.test.ts
+++ b/lib/act/__tests__/bills.test.ts
@@ -1,0 +1,181 @@
+// Material bill math: resupply (burn-based) and repair (age-prorated),
+// driven through populated APXM stores — the numbers the user will act on.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { computeResupplyBill } from '../material-groups/resupply/bill';
+import '../material-groups/repair/repair'; // side-effect: registers the Repair group
+import { act } from '../act-registry';
+import { Logger } from '../runner/logger';
+import { useSitesStore } from '../../../stores/entities/sites';
+import { useStorageStore } from '../../../stores/entities/storage';
+import { useWorkforceStore } from '../../../stores/entities/workforce';
+import { useProductionStore } from '../../../stores/entities/production';
+import {
+  resetIdCounter,
+  createTestSite,
+  createTestWorkforce,
+  createWorkforce,
+  createNeed,
+  createMaterial,
+  createMaterialAmount,
+  createTestProductionLine,
+  createOrderWithIO,
+  createStorageWithItems,
+  createPlatform,
+  createPlatformModule,
+  createDateTime,
+} from '../../../__tests__/fixtures/factories';
+
+const DAY_MS = 86_400_000;
+const SITE = 'site-r';
+
+beforeEach(() => {
+  resetIdCounter();
+  useSitesStore.getState().clear();
+  useStorageStore.getState().clear();
+  useWorkforceStore.getState().clear();
+  useProductionStore.getState().clear();
+});
+
+describe('resupply bill (computeResupplyBill)', () => {
+  // Fixture: workforce eats 4 DW + 4 RAT per day; production consumes
+  // 10 H2O/day and produces 20 RAT/day; base inventory holds 5 DW.
+  // Net daily: RAT +16 (surplus, never billed), DW −4, H2O −10.
+  function seedSite() {
+    useSitesStore.getState().setAll([createTestSite({ siteId: SITE })]);
+    useWorkforceStore.getState().setAll([
+      createTestWorkforce({
+        siteId: SITE,
+        workforces: [
+          createWorkforce({
+            needs: [
+              createNeed({ material: createMaterial({ ticker: 'DW' }), unitsPerInterval: 4 }),
+              createNeed({ material: createMaterial({ ticker: 'RAT' }), unitsPerInterval: 4 }),
+            ],
+          }),
+        ],
+      }),
+    ]);
+    useProductionStore.getState().setAll([
+      createTestProductionLine({
+        siteId: SITE,
+        capacity: 1,
+        orders: [
+          createOrderWithIO([{ ticker: 'H2O', amount: 10 }], [{ ticker: 'RAT', amount: 20 }], DAY_MS),
+        ],
+      }),
+    ]);
+    useStorageStore.getState().setAll([createStorageWithItems(SITE, [{ ticker: 'DW', amount: 5 }])]);
+  }
+
+  it('bills deficit materials for N days: ceil(consumed − inventory + 1)', () => {
+    seedSite();
+    const bill = computeResupplyBill({ type: 'Resupply' }, 'MONTEM', 10);
+    // DW: 10d × 4 = 40 consumed, 5 in stock → ceil(40 − 5 + 1) = 36.
+    // H2O: 10d × 10 = 100, none in stock → 101. RAT is net-positive → absent.
+    expect(bill).toEqual({ DW: 36, H2O: 101 });
+  });
+
+  it('consumablesOnly filters to workforce-demanded materials', () => {
+    seedSite();
+    const bill = computeResupplyBill({ type: 'Resupply', consumablesOnly: true }, 'MONTEM', 10);
+    expect(bill).toEqual({ DW: 36 });
+  });
+
+  it('exclusions drop tickers from the bill', () => {
+    seedSite();
+    const bill = computeResupplyBill({ type: 'Resupply', exclusions: ['DW'] }, 'MONTEM', 10);
+    expect(bill).toEqual({ H2O: 101 });
+  });
+
+  it('useBaseInv: false ignores base inventory', () => {
+    seedSite();
+    const bill = computeResupplyBill({ type: 'Resupply', useBaseInv: false }, 'MONTEM', 10);
+    expect(bill?.DW).toBe(41); // ceil(40 − 0 + 1)
+  });
+
+  it('returns undefined when the site or its workforce data is missing', () => {
+    expect(computeResupplyBill({ type: 'Resupply' }, 'MONTEM', 10)).toBeUndefined();
+    useSitesStore.getState().setAll([createTestSite({ siteId: SITE })]);
+    expect(computeResupplyBill({ type: 'Resupply' }, 'MONTEM', 10)).toBeUndefined();
+  });
+});
+
+describe('repair bill (Repair material group)', () => {
+  const NOW = new Date('2026-07-06T00:00:00Z').getTime();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function seedPlatform(overrides: {
+    ageDays: number;
+    lastRepairAgeDays?: number;
+    moduleType?: 'PRODUCTION' | 'CORE';
+  }) {
+    const platform = createPlatform({
+      module: createPlatformModule({ type: overrides.moduleType ?? 'PRODUCTION' }),
+      creationTime: createDateTime(NOW - overrides.ageDays * DAY_MS),
+      lastRepair:
+        overrides.lastRepairAgeDays === undefined
+          ? null
+          : createDateTime(NOW - overrides.lastRepairAgeDays * DAY_MS),
+      // 10 reclaimable + 20 repair = 30 BSE at full (180-day) proration.
+      reclaimableMaterials: [
+        createMaterialAmount({ material: createMaterial({ ticker: 'BSE' }), amount: 10 }),
+      ],
+      repairMaterials: [
+        createMaterialAmount({ material: createMaterial({ ticker: 'BSE' }), amount: 20 }),
+      ],
+    });
+    useSitesStore.getState().setAll([createTestSite({ siteId: SITE, platforms: [platform] })]);
+  }
+
+  async function repairBill(data: Partial<UserData.MaterialGroupData> = {}) {
+    const info = act.getMaterialGroupInfo('Repair');
+    expect(info).toBeDefined();
+    return info!.generateMaterialBill({
+      data: { type: 'Repair', planet: 'MONTEM', days: 60, advanceDays: 0, ...data },
+      config: {},
+      log: new Logger(() => {}),
+      setStatus: () => {},
+      setPrices: () => {},
+    });
+  }
+
+  it('prorates materials by age/180: a 90-day-old building needs half', async () => {
+    seedPlatform({ ageDays: 90 });
+    expect(await repairBill()).toEqual({ BSE: 15 }); // ceil(30 × 90 / 180)
+  });
+
+  it('caps at the full amount past 180 days', async () => {
+    seedPlatform({ ageDays: 200 });
+    expect(await repairBill()).toEqual({ BSE: 30 });
+  });
+
+  it('advanceDays shifts the age forward for both threshold and proration', async () => {
+    seedPlatform({ ageDays: 50 });
+    // 50 + 20 = 70 ≥ threshold 60 → included, prorated at 70/180.
+    expect(await repairBill({ advanceDays: 20 })).toEqual({ BSE: 12 }); // ceil(30 × 70 / 180)
+  });
+
+  it('skips buildings younger than the day threshold', async () => {
+    seedPlatform({ ageDays: 30 });
+    expect(await repairBill()).toEqual({});
+  });
+
+  it('skips non-repairable building types (CORE/HAB/STORAGE never repair)', async () => {
+    seedPlatform({ ageDays: 200, moduleType: 'CORE' });
+    expect(await repairBill()).toEqual({});
+  });
+
+  it('ages from lastRepair when the building has been repaired', async () => {
+    seedPlatform({ ageDays: 200, lastRepairAgeDays: 90 });
+    expect(await repairBill()).toEqual({ BSE: 15 }); // 90 days since repair, not 200
+  });
+});

--- a/lib/act/__tests__/compat.test.ts
+++ b/lib/act/__tests__/compat.test.ts
@@ -1,0 +1,207 @@
+// The _compat seam contract (#31): these tests pin the adapter surface the
+// ported ACT engine reads, against APXM's real store shapes. If a store
+// refactor breaks the seam, this file fails before any device testing does.
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import {
+  sitesStore,
+  warehousesStore,
+  exchangesStore,
+  materialsStore,
+  isFiniteOrder,
+  calculatePlanetBurn,
+} from '../_compat';
+import { useSitesStore } from '../../../stores/entities/sites';
+import { useStorageStore } from '../../../stores/entities/storage';
+import { useWarehouseStore } from '../../../stores/warehouses';
+import { useExchangeStore } from '../../../stores/exchanges';
+import { useMaterialsStore } from '../../../stores/reference';
+import { getEntityDisplayName } from '../../address';
+import {
+  resetIdCounter,
+  createTestSite,
+  createTestStorage,
+  createTestProductionLine,
+  createOrderWithIO,
+  createWorkforce,
+  createNeed,
+  createMaterial,
+  createStoreItem,
+  createMaterialAmountValue,
+  createStorageWithItems,
+} from '../../../__tests__/fixtures/factories';
+
+const DAY_MS = 86_400_000;
+
+beforeEach(() => {
+  resetIdCounter();
+  useSitesStore.getState().clear();
+  useStorageStore.getState().clear();
+  useMaterialsStore.getState().clear();
+  useWarehouseStore.getState().clear();
+  useExchangeStore.getState().clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('_compat materialsStore (FIO reference store adapter)', () => {
+  it('resolves weight/volume case-insensitively via the uppercase-keyed reference store', () => {
+    useMaterialsStore.getState().setAll([
+      { ticker: 'RAT', name: 'Rations', category: 'consumables (basic)', weight: 0.21, volume: 0.1 },
+    ]);
+
+    const lower = materialsStore.getByTicker('rat');
+    const upper = materialsStore.getByTicker('RAT');
+    expect(lower).toBeDefined();
+    expect(lower).toBe(upper);
+    // The engine's only material reads: cargo-fit checks and totals.
+    expect(lower!.weight).toBe(0.21);
+    expect(lower!.volume).toBe(0.1);
+    expect(lower!.weight * 100).toBeCloseTo(21);
+  });
+
+  it('returns undefined for unknown tickers (engine asserts on this)', () => {
+    expect(materialsStore.getByTicker('XYZ')).toBeUndefined();
+  });
+});
+
+describe('_compat sitesStore.getByPlanetNaturalIdOrName', () => {
+  it('finds a site by planet naturalId, siteId, and display name', () => {
+    const site = createTestSite({ siteId: 'site-x' });
+    useSitesStore.getState().setAll([site]);
+
+    expect(sitesStore.getByPlanetNaturalIdOrName('MONTEM')?.siteId).toBe('site-x');
+    expect(sitesStore.getByPlanetNaturalIdOrName('site-x')?.siteId).toBe('site-x');
+    // Display-name lookup must agree with whatever getEntityDisplayName renders.
+    const displayName = getEntityDisplayName(site.address);
+    expect(sitesStore.getByPlanetNaturalIdOrName(displayName)?.siteId).toBe('site-x');
+    expect(sitesStore.getByPlanetNaturalIdOrName('NOWHERE')).toBeUndefined();
+    expect(sitesStore.getByPlanetNaturalIdOrName(undefined)).toBeUndefined();
+  });
+});
+
+describe('_compat calculatePlanetBurn', () => {
+  it('composes core/burn rates into dailyAmount = output − input − workforce with inventory pass-through', () => {
+    // One queued 1-day order: 10 H2O in → 5 RAT out. Workforce eats 4 RAT/day.
+    const line = createTestProductionLine({
+      capacity: 1,
+      orders: [createOrderWithIO([{ ticker: 'H2O', amount: 10 }], [{ ticker: 'RAT', amount: 5 }], DAY_MS)],
+    });
+    const workforce = [
+      createWorkforce({
+        needs: [createNeed({ material: createMaterial({ ticker: 'RAT' }), unitsPerInterval: 4 })],
+      }),
+    ];
+    const stores = [createStorageWithItems('s1', [{ ticker: 'RAT', amount: 100 }])];
+
+    const burn = calculatePlanetBurn([line], workforce, stores);
+
+    expect(burn.RAT).toEqual({ dailyAmount: 1, inventory: 100, workforce: 4, input: 0, output: 5 });
+    expect(burn.H2O).toEqual({ dailyAmount: -10, inventory: 0, workforce: 0, input: 10, output: 0 });
+  });
+
+  it('treats undefined workforce/stores as empty', () => {
+    const line = createTestProductionLine({
+      capacity: 1,
+      orders: [createOrderWithIO([{ ticker: 'H2O', amount: 10 }], [], DAY_MS)],
+    });
+    const burn = calculatePlanetBurn([line], undefined, undefined);
+    expect(burn.H2O.dailyAmount).toBe(-10);
+    expect(burn.H2O.inventory).toBe(0);
+  });
+});
+
+describe('_compat warehousesStore.resolveStoreId strategy chain', () => {
+  it('resolves via WAREHOUSE_STORE.addressableId cross-reference when storeId is the empty sentinel', () => {
+    useWarehouseStore.getState().setWarehouses([
+      { warehouseId: 'wh-1', storeId: '', systemNaturalId: 'AI', stationNaturalId: 'ANT' },
+    ]);
+    useStorageStore.getState().setAll([
+      createTestStorage({ id: 'st-1', type: 'WAREHOUSE_STORE', addressableId: 'wh-1' }),
+    ]);
+
+    expect(warehousesStore.resolveStoreId('ANT')).toEqual({ storeId: 'st-1' });
+  });
+
+  it('falls back to the recorded storeId when it exists in the storage store', () => {
+    useWarehouseStore.getState().setWarehouses([
+      { warehouseId: 'wh-2', storeId: 'st-2', systemNaturalId: 'CI', stationNaturalId: 'BEN' },
+    ]);
+    useStorageStore.getState().setAll([
+      // addressableId does NOT point back at the warehouse — forces the storeId path.
+      createTestStorage({ id: 'st-2', type: 'WAREHOUSE_STORE', addressableId: 'elsewhere' }),
+    ]);
+
+    expect(warehousesStore.resolveStoreId('BEN')).toEqual({ storeId: 'st-2' });
+  });
+
+  it('falls back to the system code when the exchange code matches no station ("AI1" → "AI")', () => {
+    useWarehouseStore.getState().setWarehouses([
+      { warehouseId: 'wh-1', storeId: '', systemNaturalId: 'AI', stationNaturalId: 'ANT' },
+    ]);
+    useStorageStore.getState().setAll([
+      createTestStorage({ id: 'st-1', type: 'WAREHOUSE_STORE', addressableId: 'wh-1' }),
+    ]);
+
+    expect(warehousesStore.resolveStoreId('AI1')).toEqual({ storeId: 'st-1' });
+  });
+
+  it('returns undefined (with a diagnostic warn) when nothing matches', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(warehousesStore.resolveStoreId('NC1')).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+
+  it('returns undefined (with a diagnostic warn) when the warehouse exists but its store was never received', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    useWarehouseStore.getState().setWarehouses([
+      { warehouseId: 'wh-3', storeId: '', systemNaturalId: 'IC', stationNaturalId: 'HRT' },
+    ]);
+    expect(warehousesStore.resolveStoreId('HRT')).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});
+
+describe('_compat exchangesStore.getNaturalIdFromCode', () => {
+  it('prefers the dynamic store, falls back to the static CX map, then passes through', () => {
+    // Static fallback first (dynamic store empty after reconnect clear).
+    expect(exchangesStore.getNaturalIdFromCode('AI1')).toBe('ANT');
+    // Dynamic entry (from COMEX_BROKER_DATA) wins over the static map.
+    useExchangeStore.getState().setExchange('AI1', 'ZZZ');
+    expect(exchangesStore.getNaturalIdFromCode('AI1')).toBe('ZZZ');
+    // Unknown codes pass through unchanged.
+    expect(exchangesStore.getNaturalIdFromCode('QQ9')).toBe('QQ9');
+    expect(exchangesStore.getNaturalIdFromCode(undefined)).toBeUndefined();
+  });
+});
+
+describe('_compat isFiniteOrder', () => {
+  it('treats null-amount orders as market-maker (infinite) orders', () => {
+    expect(isFiniteOrder({ amount: null, limit: { amount: 100 } })).toBe(false);
+    expect(isFiniteOrder({ amount: 50, limit: { amount: 100 } })).toBe(true);
+  });
+});
+
+describe('_compat storage adapters used by generateState', () => {
+  it('getById returns the warehouse store with its items intact', () => {
+    useStorageStore.getState().setAll([
+      createTestStorage({
+        id: 'ws-1',
+        type: 'WAREHOUSE_STORE',
+        addressableId: 'wh-ai',
+        items: [
+          createStoreItem({
+            quantity: createMaterialAmountValue({
+              material: createMaterial({ ticker: 'RAT' }),
+              amount: 500,
+            }),
+          }),
+        ],
+      }),
+    ]);
+    const store = useStorageStore.getState().getById('ws-1');
+    expect(store?.items[0]?.quantity?.amount).toBe(500);
+  });
+});

--- a/lib/act/__tests__/cx-buy.test.ts
+++ b/lib/act/__tests__/cx-buy.test.ts
@@ -1,0 +1,157 @@
+// CX Buy: fillAmount order-book math against the real cxob store shape, and
+// generateSteps behaviour (noBuy exclusion, CX-warehouse inventory use,
+// partial-fill branches).
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import '../actions/cx-buy/cx-buy'; // side-effect: registers 'CX Buy' + CXPO_BUY step
+import { act } from '../act-registry';
+import { fillAmount } from '../actions/cx-buy/utils';
+import { Logger, type LogTag, type LogContent } from '../runner/logger';
+import type { ActionStep, ActionStepGenerateContext } from '../shared-types';
+import { useCxobStore } from '../../../stores/cxob';
+import { useSettingsStore } from '../../../stores/settings';
+import type { PrunApi } from '../../../types/prun-api';
+
+function sells(orders: Array<{ amount: number | null; price: number }>): PrunApi.CXOrderBook {
+  return {
+    sellingOrders: orders.map((o) => ({ amount: o.amount, limit: { amount: o.price } })),
+    buyingOrders: [],
+  };
+}
+
+beforeEach(() => {
+  useCxobStore.getState().clear();
+});
+
+afterEach(() => {
+  useSettingsStore.getState().setNoBuy([]);
+});
+
+describe('fillAmount', () => {
+  it('fills cheapest-first across price levels', () => {
+    useCxobStore.getState().setOrderBook(
+      'RAT.AI1',
+      sells([
+        { amount: 50, price: 100 },
+        { amount: 100, price: 90 },
+      ]),
+    );
+    // 120 wanted: 100 @ 90, then 20 @ 100.
+    expect(fillAmount('RAT.AI1', 120, Infinity)).toEqual({
+      amount: 120,
+      priceLimit: 100,
+      cost: 100 * 90 + 20 * 100,
+    });
+  });
+
+  it('stops at the price limit and reports the partial fill', () => {
+    useCxobStore.getState().setOrderBook(
+      'RAT.AI1',
+      sells([
+        { amount: 100, price: 90 },
+        { amount: 50, price: 100 },
+      ]),
+    );
+    expect(fillAmount('RAT.AI1', 120, 95)).toEqual({ amount: 100, priceLimit: 90, cost: 9000 });
+  });
+
+  it('treats market-maker orders (amount: null) as infinite supply', () => {
+    useCxobStore.getState().setOrderBook('RAT.AI1', sells([{ amount: null, price: 150 }]));
+    expect(fillAmount('RAT.AI1', 500, Infinity)).toEqual({
+      amount: 500,
+      priceLimit: 150,
+      cost: 500 * 150,
+    });
+  });
+
+  it('returns undefined when no order book has been observed', () => {
+    expect(fillAmount('DW.NC1', 10, Infinity)).toBeUndefined();
+  });
+});
+
+describe('CX Buy generateSteps', () => {
+  interface RunResult {
+    steps: ActionStep[];
+    failMessage: string | undefined;
+    failed: boolean;
+    logs: { tag: LogTag; msg: LogContent }[];
+  }
+
+  async function runCxBuy(
+    data: Partial<UserData.ActionData>,
+    materials: Record<string, number>,
+    war: Record<string, Record<string, number>> = {},
+  ): Promise<RunResult & { war: Record<string, Record<string, number>> }> {
+    const info = act.getActionInfo('CX Buy');
+    expect(info).toBeDefined();
+    const result: RunResult = { steps: [], failMessage: undefined, failed: false, logs: [] };
+    const ctx: ActionStepGenerateContext<unknown> = {
+      data: { type: 'CX Buy', name: 'buy', group: 'g', exchange: 'AI1', ...data },
+      config: {},
+      packageName: 'pkg',
+      log: new Logger((tag, msg) => result.logs.push({ tag, msg })),
+      fail: (message) => {
+        result.failed = true;
+        result.failMessage = message;
+      },
+      assert: (condition, message) => {
+        if (!condition) throw new Error(message);
+      },
+      emitStep: (step) => result.steps.push(step),
+      getMaterialGroup: async () => materials,
+      getMaterialGroupPrices: () => undefined,
+      getMaterialGroupPlanet: () => undefined,
+      state: { WAR: war },
+    };
+    await info!.generateSteps(ctx);
+    return { ...result, war };
+  }
+
+  it('emits a CXPO_BUY step per billed material', async () => {
+    useCxobStore.getState().setOrderBook('RAT.AI1', sells([{ amount: 1000, price: 90 }]));
+    const { steps, failed } = await runCxBuy({}, { RAT: 100 });
+    expect(failed).toBe(false);
+    expect(steps).toHaveLength(1);
+    expect(steps[0]).toMatchObject({ type: 'CXPO_BUY', ticker: 'RAT', amount: 100, exchange: 'AI1' });
+  });
+
+  it('skips tickers on the settings.noBuy list', async () => {
+    useSettingsStore.getState().setNoBuy(['RAT']);
+    useCxobStore.getState().setOrderBook('RAT.AI1', sells([{ amount: 1000, price: 90 }]));
+    useCxobStore.getState().setOrderBook('DW.AI1', sells([{ amount: 1000, price: 50 }]));
+    const { steps } = await runCxBuy({}, { RAT: 100, DW: 40 });
+    expect(steps).toHaveLength(1);
+    expect(steps[0]).toMatchObject({ type: 'CXPO_BUY', ticker: 'DW', amount: 40 });
+  });
+
+  it('subtracts CX warehouse inventory from the buy (useCXInv default) and mutates WAR', async () => {
+    useCxobStore.getState().setOrderBook('RAT.AI1', sells([{ amount: 1000, price: 90 }]));
+    const { steps, war } = await runCxBuy({}, { RAT: 100 }, { AI1: { RAT: 30 } });
+    expect(steps[0]).toMatchObject({ ticker: 'RAT', amount: 70 });
+    // The 30 warehoused units are consumed from the shared WAR state.
+    expect(war.AI1.RAT).toBeUndefined();
+  });
+
+  it('fails when the book cannot fill and neither buyPartial nor allowUnfilled is set', async () => {
+    useCxobStore.getState().setOrderBook('RAT.AI1', sells([{ amount: 40, price: 90 }]));
+    const { failed, failMessage, steps } = await runCxBuy({}, { RAT: 100 });
+    expect(failed).toBe(true);
+    expect(failMessage).toContain('Not enough materials on AI1');
+    expect(steps).toHaveLength(0);
+  });
+
+  it('buyPartial bids the available amount with a warning', async () => {
+    useCxobStore.getState().setOrderBook('RAT.AI1', sells([{ amount: 40, price: 90 }]));
+    const { failed, steps, logs } = await runCxBuy({ buyPartial: true }, { RAT: 100 });
+    expect(failed).toBe(false);
+    expect(steps[0]).toMatchObject({ ticker: 'RAT', amount: 40 });
+    expect(logs.some((l) => l.tag === 'WARNING')).toBe(true);
+  });
+
+  it('allowUnfilled bids the full amount regardless of book depth', async () => {
+    useCxobStore.getState().setOrderBook('RAT.AI1', sells([{ amount: 40, price: 90 }]));
+    const { failed, steps } = await runCxBuy({ allowUnfilled: true }, { RAT: 100 });
+    expect(failed).toBe(false);
+    expect(steps[0]).toMatchObject({ ticker: 'RAT', amount: 100 });
+  });
+});

--- a/lib/act/__tests__/prun-css.test.ts
+++ b/lib/act/__tests__/prun-css.test.ts
@@ -1,0 +1,45 @@
+// prun-css: parses APEX's <style data-source="prun"> CSS-module selectors
+// into the C lookup (C.Button.btn → 'Button__btn___HASH').
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import { C, loadPrunCss } from '../prun-css';
+
+function injectStyle(css: string, source?: string): HTMLStyleElement {
+  const style = document.createElement('style');
+  if (source) style.dataset.source = source;
+  style.textContent = css;
+  document.head.appendChild(style);
+  return style;
+}
+
+beforeAll(() => {
+  injectStyle('.Button__btn___UJGZ1b7 { color: red; }', 'prun');
+  injectStyle('.action-feedback__overlay-message___Xy12ab { display: none; }', 'prun');
+  injectStyle(
+    '.ComExPlaceOrderForm__form___Aa1 input, .MaterialSelector__suggestions-list___Bb2 { margin: 0; }',
+    'prun',
+  );
+  // Non-prun stylesheet must be ignored even with a matching selector shape.
+  injectStyle('.NotPrun__thing___Zz9 { color: blue; }');
+  // loadPrunCss installs a head MutationObserver — call it once per file.
+  loadPrunCss();
+});
+
+describe('loadPrunCss', () => {
+  it('maps Block__element___HASH selectors onto C', () => {
+    expect(C.Button.btn).toBe('Button__btn___UJGZ1b7');
+  });
+
+  it('camelizes dashed block and element names', () => {
+    expect(C.actionFeedback.overlayMessage).toBe('action-feedback__overlay-message___Xy12ab');
+  });
+
+  it('extracts every module class from compound selectors', () => {
+    expect(C.ComExPlaceOrderForm.form).toBe('ComExPlaceOrderForm__form___Aa1');
+    expect(C.MaterialSelector.suggestionsList).toBe('MaterialSelector__suggestions-list___Bb2');
+  });
+
+  it('ignores stylesheets without data-source="prun"', () => {
+    expect(C.NotPrun).toBeUndefined();
+  });
+});

--- a/lib/act/__tests__/register-all.test.ts
+++ b/lib/act/__tests__/register-all.test.ts
@@ -1,0 +1,25 @@
+// The dead-code keeper: until the Phase D views import the engine, this test
+// is what keeps the whole registration graph executed under vitest. A refactor
+// that breaks any self-registration fails here, not on a device.
+
+import { describe, it, expect } from 'vitest';
+import '../register-all';
+import { act } from '../act-registry';
+
+describe('register-all', () => {
+  it('registers both actions', () => {
+    expect(act.getActionTypes()).toContain('CX Buy');
+    expect(act.getActionTypes()).toContain('MTRA');
+  });
+
+  it('registers both material groups', () => {
+    expect(act.getMaterialGroupTypes()).toContain('Resupply');
+    expect(act.getMaterialGroupTypes()).toContain('Repair');
+  });
+
+  it('registers all three action steps', () => {
+    expect(act.getActionStepInfo('CXPO_BUY')).toBeDefined();
+    expect(act.getActionStepInfo('MTRA_TRANSFER')).toBeDefined();
+    expect(act.getActionStepInfo('OPEN_SFC')).toBeDefined();
+  });
+});

--- a/lib/act/__tests__/stage1.test.ts
+++ b/lib/act/__tests__/stage1.test.ts
@@ -1,0 +1,126 @@
+// Stage 1 smoke tests: prove the ported ACT runner foundation imports
+// cleanly and the pure (non-DOM, non-Vue) logic behaves. Runtime-dependent
+// pieces (step-machine DOM interaction, store-backed bills) are exercised
+// only for their input-validation / empty-data paths here; later stages add
+// integration coverage once the stores and DOM adapters are wired up.
+
+import { describe, it, expect } from 'vitest';
+import { Logger, type LogTag, type LogContent } from '../runner/logger';
+import { act } from '../act-registry';
+import { configurableValue, groupTargetPrefix } from '../shared-types';
+import { fillAmount } from '../actions/cx-buy/utils';
+import { computeResupplyBill } from '../material-groups/resupply/bill';
+
+describe('act Stage 1 — Logger', () => {
+  it('routes each level to the right tag', () => {
+    const calls: { tag: LogTag; msg: LogContent }[] = [];
+    const log = new Logger((tag, msg) => calls.push({ tag, msg }));
+
+    log.label('plain');
+    log.info('i');
+    log.action('a');
+    log.success('s');
+    log.error('e');
+    log.skip('k');
+    log.warning('w');
+    log.cancel('c');
+
+    expect(calls.map((c) => c.tag)).toEqual([
+      null,
+      'INFO',
+      'ACTION',
+      'SUCCESS',
+      'ERROR',
+      'SKIP',
+      'WARNING',
+      'CANCEL',
+    ]);
+  });
+
+  it('runtimeError emits error lines for thrown Errors', () => {
+    const tags: LogTag[] = [];
+    const log = new Logger((tag) => tags.push(tag));
+    log.runtimeError(new Error('boom'));
+    expect(tags.every((t) => t === 'ERROR')).toBe(true);
+    expect(tags.length).toBeGreaterThan(0);
+  });
+});
+
+describe('act Stage 1 — registry', () => {
+  it('addActionStep returns a factory that stamps the step type', () => {
+    const make = act.addActionStep<{ value: number }>({
+      type: 'TEST_STEP',
+      description: (d) => `value=${d.value}`,
+      execute: async () => {},
+    });
+
+    const step = make({ value: 42 });
+    expect(step.type).toBe('TEST_STEP');
+    expect(step.value).toBe(42);
+
+    const info = act.getActionStepInfo('TEST_STEP');
+    expect(info.description(step)).toBe('value=42');
+  });
+
+  it('addActionStep applies preProcessData before stamping', () => {
+    const make = act.addActionStep<{ n: number }>({
+      type: 'PRE_STEP',
+      preProcessData: (d) => ({ n: d.n * 2 }),
+      description: (d) => String(d.n),
+      execute: async () => {},
+    });
+    expect(make({ n: 3 }).n).toBe(6);
+  });
+
+  it('material group and action registration round-trips', () => {
+    act.addMaterialGroup({
+      type: 'Resupply',
+      description: () => 'resupply group',
+      editComponent: null,
+      generateMaterialBill: async () => ({}),
+    });
+    act.addAction({
+      type: 'CX Buy',
+      description: () => 'cx buy action',
+      editComponent: null,
+      generateSteps: async () => {},
+    });
+
+    expect(act.getMaterialGroupInfo('Resupply')?.description({ type: 'Resupply' })).toBe(
+      'resupply group',
+    );
+    expect(act.getMaterialGroupTypes()).toContain('Resupply');
+    expect(act.getActionInfo('CX Buy')?.type).toBe('CX Buy');
+    expect(act.getActionTypes()).toContain('CX Buy');
+  });
+});
+
+describe('act Stage 1 — shared constants', () => {
+  it('exports the rprun sentinel strings verbatim', () => {
+    expect(configurableValue).toBe('Configure on Execution');
+    expect(groupTargetPrefix).toBe('group:');
+  });
+});
+
+describe('act Stage 1 — cx-buy fillAmount', () => {
+  it('returns undefined when no order book is available (Stage 1 stub store)', () => {
+    expect(fillAmount('RAT.CI1', 100, 50)).toBeUndefined();
+  });
+});
+
+describe('act Stage 1 — resupply bill', () => {
+  const group: UserData.MaterialGroupData = { type: 'Resupply' };
+
+  it('returns undefined when planet is missing', () => {
+    expect(computeResupplyBill(group, undefined, 10)).toBeUndefined();
+  });
+
+  it('returns undefined when days is missing or NaN', () => {
+    expect(computeResupplyBill(group, 'OT-580b', undefined)).toBeUndefined();
+    expect(computeResupplyBill(group, 'OT-580b', NaN)).toBeUndefined();
+  });
+
+  it('returns undefined when the site is not loaded', () => {
+    expect(computeResupplyBill(group, 'OT-580b', 10)).toBeUndefined();
+  });
+});

--- a/lib/act/__tests__/step-generator.test.ts
+++ b/lib/act/__tests__/step-generator.test.ts
@@ -1,0 +1,119 @@
+// StepGenerator behaviour: WAR (per-CX warehouse inventory) state built from
+// live stores, action-log prefixing, and the no-steps failure path.
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { StepGenerator } from '../runner/step-generator';
+import { Logger, type LogTag, type LogContent } from '../runner/logger';
+import { act } from '../act-registry';
+import type { ActionPackageConfig, ActionStepGenerateContext } from '../shared-types';
+import { useStorageStore } from '../../../stores/entities/storage';
+import { useWarehouseStore } from '../../../stores/warehouses';
+import { useExchangeStore } from '../../../stores/exchanges';
+import {
+  resetIdCounter,
+  createTestStorage,
+  createStoreItem,
+  createMaterialAmountValue,
+  createMaterial,
+} from '../../../__tests__/fixtures/factories';
+
+// 'Refuel' is a real UserData.ActionType with no shipped implementation —
+// safe to claim as this file's probe registration (vitest isolates the
+// registry per test file).
+let capturedCtx: ActionStepGenerateContext<unknown> | undefined;
+act.addAction({
+  type: 'Refuel',
+  description: () => 'probe action',
+  editComponent: null,
+  generateSteps: async (ctx) => {
+    capturedCtx = ctx;
+    ctx.log.info('hello');
+    ctx.emitStep({ type: 'NOOP' });
+  },
+});
+
+const EMPTY_CONFIG = { materialGroups: {}, actions: {} } as unknown as ActionPackageConfig;
+
+function makeGenerator() {
+  const lines: { tag: LogTag; msg: LogContent }[] = [];
+  const generator = new StepGenerator({
+    log: new Logger((tag, msg) => lines.push({ tag, msg })),
+    onStatusChanged: () => {},
+  });
+  return { generator, lines };
+}
+
+beforeEach(() => {
+  resetIdCounter();
+  capturedCtx = undefined;
+  useStorageStore.getState().clear();
+  useWarehouseStore.getState().clear();
+  useExchangeStore.getState().clear();
+});
+
+describe('StepGenerator.generateSteps', () => {
+  it('builds WAR state from warehouse + storage stores via the static CX map', async () => {
+    useWarehouseStore.getState().setWarehouses([
+      { warehouseId: 'wh-ai', storeId: 'ws-1', systemNaturalId: 'AI', stationNaturalId: 'ANT' },
+    ]);
+    useStorageStore.getState().setAll([
+      createTestStorage({
+        id: 'ws-1',
+        type: 'WAREHOUSE_STORE',
+        addressableId: 'wh-ai',
+        items: [
+          createStoreItem({
+            quantity: createMaterialAmountValue({
+              material: createMaterial({ ticker: 'RAT' }),
+              amount: 500,
+            }),
+          }),
+        ],
+      }),
+    ]);
+
+    const { generator } = makeGenerator();
+    const result = await generator.generateSteps(
+      { global: { name: 'pkg' }, groups: [], actions: [{ type: 'Refuel', name: 'a1' }] },
+      EMPTY_CONFIG,
+    );
+
+    expect(result.fail).toBe(false);
+    expect(result.steps).toEqual([{ type: 'NOOP' }]);
+    expect(capturedCtx?.state.WAR['AI1']).toEqual({ RAT: 500 });
+    // Exchanges with no warehouse still get an (empty) WAR bucket.
+    expect(capturedCtx?.state.WAR['CI1']).toEqual({});
+    expect(capturedCtx?.state.WAR['IC1']).toEqual({});
+    expect(capturedCtx?.state.WAR['NC1']).toEqual({});
+  });
+
+  it('prefixes action log lines with the action name', async () => {
+    const { generator, lines } = makeGenerator();
+    await generator.generateSteps(
+      { global: { name: 'pkg' }, groups: [], actions: [{ type: 'Refuel', name: 'a1' }] },
+      EMPTY_CONFIG,
+    );
+    expect(lines).toContainEqual({ tag: 'INFO', msg: '[a1] hello' });
+  });
+
+  it('fails with "No actions were generated" when the package emits no steps', async () => {
+    const { generator, lines } = makeGenerator();
+    const result = await generator.generateSteps(
+      { global: { name: 'pkg' }, groups: [], actions: [] },
+      EMPTY_CONFIG,
+    );
+    expect(result.fail).toBe(true);
+    expect(result.steps).toEqual([]);
+    expect(lines).toContainEqual({ tag: 'ERROR', msg: 'No actions were generated' });
+  });
+
+  it('skips unregistered action types (and then fails on zero steps)', async () => {
+    const { generator } = makeGenerator();
+    const result = await generator.generateSteps(
+      { global: { name: 'pkg' }, groups: [], actions: [{ type: 'CONT Ship', name: 'c1' }] },
+      EMPTY_CONFIG,
+    );
+    expect(result.steps).toEqual([]);
+    expect(result.fail).toBe(true);
+  });
+});

--- a/lib/act/__tests__/step-machine-gate.test.ts
+++ b/lib/act/__tests__/step-machine-gate.test.ts
@@ -1,0 +1,172 @@
+// The autoConfirm gate: APEX's post-ACT confirmation overlay is auto-clicked
+// ONLY when settings.autoConfirm is on. The default (false) waits for the
+// user to tap CONFIRM in APEX themselves — the action-authorisation rule —
+// and must bring the hidden buffer on-screen so that tap is possible.
+
+import { describe, it, expect, beforeEach, beforeAll, vi } from 'vitest';
+
+// stop() closes the mobile buffer; that drives APEX Stack DOM jsdom doesn't
+// have. The navigator is device-validated in Phase D — stub it out here.
+vi.mock('../../mobile-buffer-navigator', () => ({
+  openMobileBuffer: vi.fn(async () => true),
+  closeMobileBuffer: vi.fn(async () => {}),
+}));
+
+import { StepMachine } from '../runner/step-machine';
+import { act } from '../act-registry';
+import { setupActGlobals } from '../globals-setup';
+import { C } from '../prun-css';
+import { Logger, type LogTag, type LogContent } from '../runner/logger';
+import { useSettingsStore } from '../../../stores/settings';
+
+// Synthetic APEX class names for the overlay state machine.
+beforeAll(() => {
+  setupActGlobals();
+  Object.assign(C, {
+    ActionFeedback: {
+      overlay: 'af-overlay',
+      progress: 'af-progress',
+      success: 'af-success',
+      error: 'af-error',
+      message: 'af-message',
+      dismiss: 'af-dismiss',
+    },
+    ActionConfirmationOverlay: { container: 'aco-container' },
+    Button: { btn: 'apex-btn' },
+  });
+});
+
+// Test step: runs waitActionFeedback against the fixture anchor, then completes.
+let anchorEl: HTMLElement;
+const makeGateStep = act.addActionStep<Record<string, never>>({
+  type: 'GATE_TEST',
+  description: () => 'gate test step',
+  execute: async (ctx) => {
+    await ctx.waitActionFeedback({ anchor: anchorEl });
+    ctx.complete();
+  },
+});
+
+interface Fixture {
+  anchor: HTMLElement;
+  overlay: HTMLElement;
+  confirmBtn: HTMLElement;
+  confirmClicks: () => number;
+}
+
+// Overlay starts in the confirmation state, inside an off-screen anchor
+// (the state openMobileBuffer leaves #container in).
+function buildConfirmationOverlay(): Fixture {
+  const anchor = document.createElement('div');
+  anchor.style.visibility = 'hidden';
+  anchor.style.left = '-9999px';
+  document.body.appendChild(anchor);
+  anchorEl = anchor;
+
+  const overlay = document.createElement('div');
+  overlay.className = 'af-overlay aco-container';
+  const cancelBtn = document.createElement('button');
+  cancelBtn.className = 'apex-btn';
+  const confirmBtn = document.createElement('button');
+  confirmBtn.className = 'apex-btn';
+  let clicks = 0;
+  confirmBtn.addEventListener('click', () => {
+    clicks++;
+    // APEX transitions the same element: confirmation → success.
+    overlay.classList.remove('aco-container');
+    overlay.classList.add('af-success');
+  });
+  overlay.append(cancelBtn, confirmBtn);
+  anchor.appendChild(overlay);
+  return { anchor, overlay, confirmBtn, confirmClicks: () => clicks };
+}
+
+function runMachine() {
+  const logs: { tag: LogTag; msg: LogContent }[] = [];
+  let resolveEnd!: () => void;
+  const done = new Promise<void>((r) => (resolveEnd = r));
+  const machine = new StepMachine([makeGateStep({})], {
+    log: new Logger((tag, msg) => logs.push({ tag, msg })),
+    onBufferSplit: () => {},
+    onStart: () => {},
+    onEnd: () => resolveEnd(),
+    onStatusChanged: () => {},
+    onActReady: () => {},
+  });
+  machine.start();
+  const errors = () => logs.filter((l) => l.tag === 'ERROR').map((l) => l.msg);
+  return { done, errors };
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  useSettingsStore.getState().setAutoConfirm(false);
+});
+
+describe('settings default', () => {
+  it('autoConfirm defaults to false (manual confirm is the shipped behaviour)', () => {
+    expect(useSettingsStore.getInitialState().autoConfirm).toBe(false);
+  });
+});
+
+describe('waitActionFeedback confirmation gate', () => {
+  it('autoConfirm ON: clicks the confirm button (second APEX button) itself', async () => {
+    useSettingsStore.getState().setAutoConfirm(true);
+    const fixture = buildConfirmationOverlay();
+    const { done, errors } = runMachine();
+    await done;
+    expect(fixture.confirmClicks()).toBe(1);
+    expect(errors()).toEqual([]);
+  });
+
+  it('autoConfirm OFF: never clicks, un-hides the buffer for the user tap, and restores it after', async () => {
+    const fixture = buildConfirmationOverlay();
+    let visibilityDuringWait: string | undefined;
+    let leftDuringWait: string | undefined;
+    // Simulate the user tapping CONFIRM in APEX a beat later.
+    setTimeout(() => {
+      visibilityDuringWait = fixture.anchor.style.visibility;
+      leftDuringWait = fixture.anchor.style.left;
+      fixture.overlay.classList.remove('aco-container');
+      fixture.overlay.classList.add('af-success');
+    }, 20);
+
+    const { done, errors } = runMachine();
+    await done;
+
+    expect(fixture.confirmClicks()).toBe(0);
+    // The gate brought the off-screen buffer on-screen so the tap was possible…
+    expect(visibilityDuringWait).toBe('visible');
+    expect(leftDuringWait).toBe('0px');
+    // …and put it back afterwards.
+    expect(fixture.anchor.style.visibility).toBe('hidden');
+    expect(fixture.anchor.style.left).toBe('-9999px');
+    expect(errors()).toEqual([]);
+  });
+
+  it('autoConfirm OFF: overlay removal (user cancelled in APEX) fails the step instead of hanging', async () => {
+    const fixture = buildConfirmationOverlay();
+    setTimeout(() => fixture.overlay.remove(), 20);
+
+    const { done, errors } = runMachine();
+    await done;
+
+    expect(fixture.confirmClicks()).toBe(0);
+    expect(errors()).toContain('Unknown action feedback overlay');
+    // Styles restored even on the failure path.
+    expect(fixture.anchor.style.visibility).toBe('hidden');
+    expect(fixture.anchor.style.left).toBe('-9999px');
+  });
+
+  it('skips the gate entirely when the overlay is already past confirmation', async () => {
+    const fixture = buildConfirmationOverlay();
+    fixture.overlay.classList.remove('aco-container');
+    fixture.overlay.classList.add('af-success');
+
+    const { done, errors } = runMachine();
+    await done;
+
+    expect(fixture.confirmClicks()).toBe(0);
+    expect(errors()).toEqual([]);
+  });
+});

--- a/lib/act/_compat.ts
+++ b/lib/act/_compat.ts
@@ -1,0 +1,320 @@
+// Compatibility shims for refined-prun primitives that the ported ACT runner
+// expects. Stage 1 ports the runner verbatim; APXM does not yet have all of
+// the prun-api stores, DOM helpers, or utility functions that rprun pulls in,
+// so this module collects the missing pieces in one place. Each shim is either
+// adapted to an existing APXM equivalent or stubbed to a safe default for
+// later stages to wire up.
+
+import type { PrunApi } from '../../types/prun-api';
+
+// ---------------------------------------------------------------------------
+// Stores — adapt APXM's entity stores to the rprun-style singleton API used by
+// the runner. The methods exposed here are exactly the ones the ported files
+// call; anything else can be added incrementally.
+// ---------------------------------------------------------------------------
+
+import { useSitesStore } from '../../stores/entities/sites';
+import {
+  getStorageByAddressableId as apxmGetStorageByAddressableId,
+  useStorageStore,
+} from '../../stores/entities/storage';
+import { getWorkforceBySiteId } from '../../stores/entities/workforce';
+import { getProductionBySiteId } from '../../stores/entities/production';
+import { getEntityDisplayName } from '../address';
+import {
+  calculateProductionRates,
+  calculateWorkforceConsumption,
+  getInventoryFromStores,
+} from '../../core/burn';
+import { useWarehouseStore, type WarehouseLocation } from '../../stores/warehouses';
+import { useExchangeStore } from '../../stores/exchanges';
+import { useMaterialsStore, type MaterialInfo } from '../../stores/reference';
+import { useCxobStore } from '../../stores/cxob';
+import { warn } from '../debug/logger';
+
+export const sitesStore = {
+  getByPlanetNaturalIdOrName(query: string | undefined): PrunApi.Site | undefined {
+    if (!query) return undefined;
+    const all = useSitesStore.getState().getAll();
+    return (
+      all.find((s) => s.address?.lines?.some((l) => l.entity?.naturalId === query)) ??
+      all.find((s) => s.siteId === query) ??
+      all.find((s) => getEntityDisplayName(s.address) === query)
+    );
+  },
+};
+
+export const workforcesStore = {
+  getById(siteId: string | undefined) {
+    if (!siteId) return undefined;
+    const wf = getWorkforceBySiteId(siteId);
+    return wf ? { workforces: wf.workforces } : undefined;
+  },
+};
+
+export const productionStore = {
+  getBySiteId(siteId: string | undefined) {
+    if (!siteId) return undefined;
+    return getProductionBySiteId(siteId);
+  },
+};
+
+export const storagesStore = {
+  getByAddressableId(addressableId: string | undefined): PrunApi.Store[] {
+    if (!addressableId) return [];
+    return apxmGetStorageByAddressableId(addressableId);
+  },
+  getById(_id: string | undefined): PrunApi.Store | undefined {
+    if (!_id) return undefined;
+    return useStorageStore.getState().getById(_id);
+  },
+  getByName(name: string | null | undefined): PrunApi.Store | undefined {
+    if (!name) return undefined;
+    return useStorageStore.getState().getAll().find((s) => s.name === name);
+  },
+  getByNameAndType(name: string, type: PrunApi.StoreType): PrunApi.Store | undefined {
+    return useStorageStore.getState().getAll().find((s) => s.name === name && s.type === type);
+  },
+};
+
+// Derive the system natural ID from a CX exchange code, e.g. "AI1" → "AI".
+function deriveSystemCode(exchangeCode: string): string | undefined {
+  const m = exchangeCode.match(/^([A-Z]+)\d+$/);
+  return m ? m[1] : undefined;
+}
+
+// Multi-strategy CX warehouse lookup:
+//   1. Exact stationNaturalId match (exchange code == station entity naturalId)
+//   2. Cross-reference via WAREHOUSE_STORE.addressableId when storeId not in storage store
+//   3. System-code fallback (exchange "AI1" → systemNaturalId "AI")
+// Each strategy also tries to find the PrunApi.Store via addressableId if getById misses.
+function resolveWarehouseStore(exchangeCode: string): { storeId: string } | undefined {
+  const warehouseState = useWarehouseStore.getState();
+  const storageState = useStorageStore.getState();
+
+  function storeIdFromWarehouseId(warehouseId: string): string | undefined {
+    const wh = warehouseState.warehouses.find(w => w.warehouseId === warehouseId);
+    if (!wh) return undefined;
+    // Primary: cross-reference via addressableId === warehouseId. Per rprun,
+    // Store.addressableId for a CX warehouse always points to the warehouse
+    // entity itself, so this match is authoritative regardless of how storeId
+    // was parsed from the original message.
+    const byAddr = storageState.getAll()
+      .find(s => s.type === 'WAREHOUSE_STORE' && s.addressableId === warehouseId);
+    if (byAddr) return byAddr.id;
+    // Secondary: the recorded storeId if it's already present in the storage store.
+    // Treat "" as a sentinel (extractWarehouse fell back to empty — no top-level field).
+    if (wh.storeId && storageState.getById(wh.storeId)) return wh.storeId;
+    // Both strategies failed — the Store is not in the storage store yet.
+    // Return undefined so resolveWarehouseStore logs the full diagnostic rather
+    // than silently returning a storeId that getById() will reject later.
+    console.warn(
+      `[APXM] _compat: warehouse ${warehouseId.slice(0, 8)} storeId=${wh.storeId ? wh.storeId.slice(0, 8) : '(empty)'} not found in storage store — STORAGE_STORAGES may not include WAREHOUSE_STORE entries`,
+    );
+    return undefined;
+  }
+
+  // Strategy 1: stationNaturalId or systemNaturalId exact match
+  const loc = warehouseState.getByEntityNaturalId(exchangeCode);
+  if (loc) {
+    const sid = storeIdFromWarehouseId(loc.warehouseId);
+    if (sid) return { storeId: sid };
+  }
+
+  // Strategy 2: system-code fallback
+  const systemCode = deriveSystemCode(exchangeCode);
+  if (systemCode) {
+    const bySystem = warehouseState.getBySystem(systemCode);
+    if (bySystem) {
+      const sid = storeIdFromWarehouseId(bySystem.warehouseId);
+      if (sid) {
+        warn(`_compat: warehouse for '${exchangeCode}' matched by system '${systemCode}' — may be ambiguous if you have warehouses at two ${systemCode} exchanges`);
+        return { storeId: sid };
+      }
+    }
+  }
+
+  // Nothing found — always-visible diagnostics (not gated by ?apxm_debug).
+  const whSnapshot = warehouseState.warehouses.map(w =>
+    `[${w.warehouseId.slice(0, 8)} sys=${w.systemNaturalId} sta=${w.stationNaturalId ?? 'null'} storeId=${w.storeId ? w.storeId.slice(0, 8) : '(empty)'}]`
+  ).join(', ');
+  // Also dump every WAREHOUSE_STORE entry in the storage store — if these exist
+  // but the warehouse store is empty, STORAGE_STORAGES has the inventory but
+  // WAREHOUSE_STORAGES never populated the location lookup table.
+  const storageWhEntries = storageState.getAll()
+    .filter(s => s.type === 'WAREHOUSE_STORE')
+    .map(s => `[id=${s.id.slice(0, 8)} addr=${s.addressableId.slice(0, 8)} name=${s.name ?? 'null'}]`)
+    .join(', ');
+  console.warn(
+    `[APXM] CX warehouse not found for '${exchangeCode}'.` +
+    `\n  useWarehouseStore entries: ${whSnapshot || '(empty — WAREHOUSE_STORAGES not processed?)'}` +
+    `\n  storageStore WAREHOUSE_STORE entries: ${storageWhEntries || '(none — not in STORAGE_STORAGES either)'}`,
+  );
+  return undefined;
+}
+
+export const warehousesStore = {
+  getByEntityNaturalId(naturalId: string | undefined): WarehouseLocation | undefined {
+    if (!naturalId) return undefined;
+    return useWarehouseStore.getState().getByEntityNaturalId(naturalId);
+  },
+  resolveStoreId(naturalId: string | undefined): { storeId: string } | undefined {
+    if (!naturalId) return undefined;
+    return resolveWarehouseStore(naturalId);
+  },
+};
+
+// Static mapping of CX exchange codes to their station entity naturalIds.
+// These are fundamental game constants — the 4 commodity exchanges in PrUn.
+const CX_STATION_NATURAL_IDS: Record<string, string> = {
+  AI1: 'ANT',  // Antares Industrial Exchange
+  CI1: 'BEN',  // Benten Commodity Exchange
+  NC1: 'MOR',  // Moria Transit Exchange
+  IC1: 'HRT',  // Hort Trade Center
+};
+
+export const exchangesStore = {
+  getNaturalIdFromCode(code: string | undefined): string | undefined {
+    if (!code) return undefined;
+    // Dynamic store (populated from COMEX_BROKER_DATA when a CX buffer is opened)
+    // takes priority; static map is the reliable fallback for login-time lookups.
+    return useExchangeStore.getState().getNaturalIdFromCode(code)
+      ?? CX_STATION_NATURAL_IDS[code]
+      ?? code;
+  },
+};
+
+// The engine only reads ticker/weight/volume (cargo-fit checks and totals).
+// Main sources materials from the FIO reference store rather than the fork's
+// WS-derived store; MaterialInfo carries exactly the fields the engine needs.
+export type Material = MaterialInfo;
+
+export const materialsStore = {
+  getByTicker(ticker: string): Material | undefined {
+    // Reference store keys are uppercase tickers.
+    return useMaterialsStore.getState().getById(ticker.toUpperCase());
+  },
+};
+
+export type CXOrder = import('../../types/prun-api').PrunApi.CXOrder;
+export type CXOrderBook = import('../../types/prun-api').PrunApi.CXOrderBook;
+
+export const cxobStore = {
+  getByTicker(cxTicker: string): CXOrderBook | undefined {
+    return useCxobStore.getState().getByTicker(cxTicker);
+  },
+};
+
+export function isFiniteOrder(order: CXOrder): boolean {
+  return order.amount !== null && Number.isFinite(order.amount);
+}
+
+// ---------------------------------------------------------------------------
+// Utility functions
+// ---------------------------------------------------------------------------
+
+export function fixed0(value: number): string {
+  return Math.round(value).toString();
+}
+
+export function fixed02(value: number): string {
+  return value.toFixed(2);
+}
+
+export function fixed1(value: number): string {
+  return value.toFixed(1).replace(/\.0$/, '');
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Wait until condition() returns true, polling every intervalMs.
+ * Rejects with an Error after timeoutMs if condition never becomes true.
+ *
+ * Replaces Vue's watchWhile(cond) pattern: watchWhile(() => x) waits while x
+ * is truthy, so the APXM equivalent is waitUntil(() => !x).
+ */
+export function waitUntil(
+  condition: () => boolean,
+  intervalMs = 100,
+  timeoutMs = 15000,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (condition()) {
+      resolve();
+      return;
+    }
+    const interval = setInterval(() => {
+      if (condition()) {
+        clearInterval(interval);
+        resolve();
+      }
+    }, intervalMs);
+    setTimeout(() => {
+      clearInterval(interval);
+      reject(new Error('waitUntil timed out'));
+    }, timeoutMs);
+  });
+}
+
+export function focusElement(el: Element): void {
+  (el as HTMLElement).focus();
+}
+
+// `deepToRaw` in rprun strips Vue reactivity wrappers. In APXM the data is
+// already plain so this is identity.
+export function deepToRaw<T>(value: T): T {
+  return value;
+}
+
+// `clickElement` in rprun dispatches a mouse click via a small helper. On
+// mobile WebKit a synthetic click on the element is sufficient.
+export async function clickElement(el: Element): Promise<void> {
+  (el as HTMLElement).click();
+}
+
+// ---------------------------------------------------------------------------
+// Burn calculation — APXM currently exposes per-site burn through
+// core/burn.ts, not a planet-level function. Stub to undefined-friendly shape
+// until later stages port the equivalent of rprun's calculatePlanetBurn.
+// ---------------------------------------------------------------------------
+
+export interface MaterialBurn {
+  dailyAmount: number;
+  inventory: number;
+  workforce: number;
+  input: number;
+  output: number;
+}
+
+export type PlanetBurn = Record<string, MaterialBurn>;
+
+export function calculatePlanetBurn(
+  production: PrunApi.ProductionLine[],
+  workforce: PrunApi.Workforce[] | undefined,
+  stores: PrunApi.Store[] | undefined,
+): PlanetBurn {
+  const prodRates = calculateProductionRates(production);
+  const wfRates = calculateWorkforceConsumption(workforce ?? []);
+  const inventory = getInventoryFromStores(stores ?? []);
+
+  const tickers = new Set([...prodRates.keys(), ...wfRates.keys()]);
+  const result: PlanetBurn = {};
+  for (const ticker of tickers) {
+    const prod = prodRates.get(ticker);
+    const wf = wfRates.get(ticker)?.consumption ?? 0;
+    const inv = inventory.get(ticker) ?? 0;
+    const input = prod?.input ?? 0;
+    const output = prod?.output ?? 0;
+    result[ticker] = {
+      dailyAmount: output - input - wf,
+      inventory: inv,
+      workforce: wf,
+      input,
+      output,
+    };
+  }
+  return result;
+}

--- a/lib/act/act-registry.ts
+++ b/lib/act/act-registry.ts
@@ -1,0 +1,103 @@
+// Ported from refined-prun src/features/XIT/ACT/act-registry.ts.
+// Vue's `Component` import is dropped; edit/configure component handles are
+// stored as opaque `unknown` so APXM can plug in React components later.
+
+import {
+  ActionStep,
+  ActionStepExecuteContext,
+  ActionStepGenerateContext,
+  MaterialGroupGenerateContext,
+} from './shared-types';
+
+// Opaque editor/configure component handle. In refined-prun this is Vue's
+// `Component`; in APXM it will be a React component or descriptor.
+type EditorComponent = unknown;
+
+interface MaterialGroupInfo<TConfig> {
+  type: UserData.MaterialGroupType;
+  shortDescription?: string;
+  description: (data: UserData.MaterialGroupData, config?: TConfig) => string;
+  editComponent: EditorComponent;
+  configureComponent?: EditorComponent;
+  needsConfigure?: (data: UserData.MaterialGroupData) => boolean;
+  isValidConfig?: (data: UserData.MaterialGroupData, config: TConfig) => boolean;
+  generateMaterialBill: (
+    ctx: MaterialGroupGenerateContext<TConfig>,
+  ) => Promise<Record<string, number> | undefined>;
+}
+
+const materialGroups: MaterialGroupInfo<unknown>[] = [];
+
+function addMaterialGroup<TConfig>(info: MaterialGroupInfo<TConfig>) {
+  materialGroups.push(info as MaterialGroupInfo<unknown>);
+}
+
+function getMaterialGroupInfo(type: UserData.MaterialGroupType) {
+  return materialGroups.find(x => x.type === type);
+}
+
+function getMaterialGroupTypes() {
+  return materialGroups.map(x => x.type);
+}
+
+interface ActionInfo<TConfig> {
+  type: UserData.ActionType;
+  shortDescription?: string;
+  description: (data: UserData.ActionData, config?: TConfig) => string;
+  editComponent: EditorComponent;
+  configureComponent?: EditorComponent;
+  needsConfigure?: (data: UserData.ActionData) => boolean;
+  isValidConfig?: (data: UserData.ActionData, config: TConfig) => boolean;
+  generateSteps: (ctx: ActionStepGenerateContext<TConfig>) => Promise<void>;
+}
+
+const actions: ActionInfo<unknown>[] = [];
+
+function addAction<TConfig>(info: ActionInfo<TConfig>) {
+  actions.push(info as ActionInfo<unknown>);
+}
+
+function getActionInfo(type: UserData.ActionType) {
+  return actions.find(x => x.type === type);
+}
+
+function getActionTypes() {
+  return actions.map(x => x.type);
+}
+
+interface ActionStepInfo<T> {
+  type: string;
+  preProcessData?: (data: T) => T;
+  description: (data: T) => string;
+  totalMaterials?: (data: T) => Record<string, number>;
+  execute: (ctx: ActionStepExecuteContext<T>) => Promise<void>;
+}
+
+const actionSteps: ActionStepInfo<unknown>[] = [];
+
+function addActionStep<T>(info: ActionStepInfo<T>) {
+  actionSteps.push(info as ActionStepInfo<unknown>);
+  return (data: T) => {
+    return {
+      ...(info.preProcessData?.(data) ?? data),
+      type: info.type,
+    } as T & ActionStep;
+  };
+}
+
+function getActionStepInfo(type: string) {
+  // Use ! operator here because there is a runtime guarantee
+  // that all action steps have existing type (see addActionStep).
+  return actionSteps.find(x => x.type === type)!;
+}
+
+export const act = {
+  addMaterialGroup,
+  getMaterialGroupInfo,
+  getMaterialGroupTypes,
+  addAction,
+  getActionInfo,
+  getActionTypes,
+  addActionStep,
+  getActionStepInfo,
+};

--- a/lib/act/action-steps/CXPO_BUY.ts
+++ b/lib/act/action-steps/CXPO_BUY.ts
@@ -1,0 +1,195 @@
+// Ported from refined-prun src/features/XIT/ACT/action-steps/CXPO_BUY.ts.
+//
+// Vue adaptations:
+//   watchEffect(fill inputs reactively) → plain function called once before waitAct
+//   computed(() => cxWarehouse)         → inline getter () => cxWarehouse
+//   watchWhile(() => cond)              → await waitUntil(() => !cond)
+//   changeInputValue(el, val)           → setInputValue(el, val)
+//   warehouseAmount.value               → warehouseAmount()
+//   unwatch()                           → removed (no subscription to clean up)
+
+import { act } from '../act-registry';
+import { fixed0, fixed02, fixed1, clickElement, waitUntil, cxobStore } from '../_compat';
+import { setInputValue } from '../../buffer-refresh/dom-helpers';
+import { fillAmount } from '../actions/cx-buy/utils';
+import { storagesStore, exchangesStore, warehousesStore, materialsStore } from '../_compat';
+import type { AssertFn } from '../shared-types';
+
+interface Data {
+  exchange: string;
+  ticker: string;
+  amount: number;
+  priceLimit: number;
+  buyPartial: boolean;
+  allowUnfilled: boolean;
+}
+
+export const CXPO_BUY = act.addActionStep<Data>({
+  type: 'CXPO_BUY',
+  preProcessData: data => ({ ...data, ticker: data.ticker.toUpperCase() }),
+  description: data => {
+    const { ticker, exchange } = data;
+    const cxTicker = `${ticker}.${exchange}`;
+    const filled = fillAmount(cxTicker, data.amount, data.priceLimit);
+    const amount = filled?.amount ?? data.amount;
+    const priceLimit = filled?.priceLimit ?? data.priceLimit;
+    const allowUnfilled = data.allowUnfilled ?? false;
+    const willFillCompletely = filled && filled.amount === data.amount;
+
+    if (!willFillCompletely && allowUnfilled) {
+      let description = `Bid for ${fixed0(data.amount)} ${ticker} on ${exchange}`;
+      if (isFinite(priceLimit)) {
+        description += ` at price ${fixed02(data.priceLimit)}`;
+        description += ` (tot: ${fixed1(data.amount * data.priceLimit)})`;
+      }
+      return description;
+    }
+
+    let description = `Buy ${fixed0(amount)} ${ticker} on ${exchange}`;
+    if (isFinite(priceLimit)) {
+      description += ` with price limit ${fixed02(priceLimit)}`;
+    }
+    if (filled) {
+      description += ` (tot: ${fixed1(filled.cost)})`;
+    } else {
+      description += ' (no price data yet)';
+    }
+    return description;
+  },
+  execute: async ctx => {
+    const { data, log, setStatus, requestTile, waitAct, waitActionFeedback, complete, skip, fail } =
+      ctx;
+    const assert: AssertFn = ctx.assert;
+    const { amount, ticker, exchange, priceLimit } = data;
+    const cxTicker = `${ticker}.${exchange}`;
+
+    // Getter reads current Zustand state each time it is called.
+    const getCxWarehouse = () => {
+      const naturalId = exchangesStore.getNaturalIdFromCode(exchange);
+      const warehouse = warehousesStore.getByEntityNaturalId(naturalId);
+      return storagesStore.getById(warehouse?.storeId);
+    };
+    assert(getCxWarehouse(), `CX warehouse not found for ${exchange}`);
+
+    if (amount <= 0) {
+      log.warning(`No ${ticker} was bought (target amount is 0)`);
+      skip();
+      return;
+    }
+
+    const material = materialsStore.getByTicker(ticker);
+    assert(material, `Unknown material ${ticker}`);
+
+    const warehouse = getCxWarehouse()!;
+    const canFitWeight =
+      material.weight * amount <= warehouse.weightCapacity - warehouse.weightLoad;
+    const canFitVolume =
+      material.volume * amount <= warehouse.volumeCapacity - warehouse.volumeLoad;
+    assert(
+      canFitWeight && canFitVolume,
+      `Cannot buy ${fixed0(amount)} ${ticker} (will not fit in the warehouse)`,
+    );
+
+    const tile = await requestTile(`CXPO ${cxTicker}`);
+    if (!tile) {
+      return;
+    }
+
+    setStatus('Setting up CXPO buffer...');
+
+    const buyButton = await $(tile.anchor, C.Button.success);
+    const form = await $(tile.anchor, C.ComExPlaceOrderForm.form);
+    const inputs = _$$<HTMLInputElement>(form!, 'input');
+    const quantityInput = inputs[0];
+    assert(quantityInput !== undefined, 'Missing quantity input');
+    const priceInput = inputs[1];
+    assert(priceInput !== undefined, 'Missing price input');
+
+    // Opening the CXPO tile triggers COMEX_BROKER_DATA which populates the
+    // order book asynchronously. Wait for it — this replaces Vue's watchEffect
+    // which re-ran reactively whenever the store changed.
+    await waitUntil(() => cxobStore.getByTicker(cxTicker) !== undefined, 100, 8000)
+      .catch(() => {});
+
+    const filled = fillAmount(cxTicker, amount, priceLimit);
+
+    if (!filled) {
+      fail(`Missing ${cxTicker} order book data`);
+      return;
+    }
+
+    if (filled.amount < amount && !data.allowUnfilled) {
+      if (!data.buyPartial) {
+        let message = `Not enough materials on ${exchange} to buy ${fixed0(amount)} ${ticker}`;
+        if (isFinite(priceLimit)) {
+          message += ` with price limit ${fixed02(priceLimit)}/u`;
+        }
+        fail(message);
+        return;
+      }
+
+      const leftover = amount - filled.amount;
+      let message =
+        `${fixed0(leftover)} ${ticker} will not be bought on ${exchange} ` +
+        `(${fixed0(filled.amount)} of ${fixed0(amount)} available`;
+      if (isFinite(priceLimit)) {
+        message += ` with price limit ${fixed02(priceLimit)}/u`;
+      }
+      message += ')';
+      log.warning(message);
+
+      if (filled.amount === 0) {
+        skip();
+        return;
+      }
+    }
+
+    if (data.allowUnfilled) {
+      setInputValue(quantityInput, data.amount.toString());
+      setInputValue(priceInput, fixed02(data.priceLimit));
+    } else {
+      setInputValue(quantityInput, filled.amount.toString());
+      setInputValue(priceInput, fixed02(filled.priceLimit));
+    }
+
+    // Cache description before clicking buy — order book changes after submission.
+    ctx.cacheDescription();
+
+    // Allow the user to override the auto-filled values before confirming.
+    function onManualInput(event: Event) {
+      if (event.isTrusted) {
+        log.info('Manual input detected; keeping user-entered quantity and price');
+      }
+    }
+    quantityInput.addEventListener('input', onManualInput);
+    priceInput.addEventListener('input', onManualInput);
+
+    await waitAct();
+    quantityInput.removeEventListener('input', onManualInput);
+    priceInput.removeEventListener('input', onManualInput);
+
+    // Getter for warehouse amount — reads live Zustand state.
+    const getWarehouseAmount = () => {
+      return (
+        getCxWarehouse()
+          ?.items.filter(x => x.quantity !== null && x.quantity !== undefined)
+          .find(x => x.quantity!.material.ticker === ticker)?.quantity?.amount ?? 0
+      );
+    };
+    const currentAmount = getWarehouseAmount();
+    const amountToFill = fillAmount(cxTicker, amount, priceLimit)?.amount ?? 0;
+    const shouldWaitForUpdate = amountToFill > 0;
+
+    await clickElement(buyButton!);
+    await waitActionFeedback(tile);
+
+    if (shouldWaitForUpdate) {
+      setStatus('Waiting for storage update...');
+      await waitUntil(() => getWarehouseAmount() !== currentAmount);
+    } else {
+      setStatus('Bid order created');
+    }
+
+    complete();
+  },
+});

--- a/lib/act/action-steps/MTRA_TRANSFER.ts
+++ b/lib/act/action-steps/MTRA_TRANSFER.ts
@@ -1,0 +1,173 @@
+// Ported from refined-prun src/features/XIT/ACT/action-steps/MTRA_TRANSFER.ts.
+//
+// Vue adaptations:
+//   computed(() => X)               → inline getter () => X
+//   watchWhile(() => cond)          → await waitUntil(() => !cond)
+//   changeInputValue(el, val)       → setInputValue(el, val)
+//   destinationAmount.value         → destinationAmount()
+//
+// Scope: all DOM queries are scoped to tile.anchor (#container on mobile).
+
+import { act } from '../act-registry';
+import { serializeStorage } from '../actions/utils';
+import { fixed0, clickElement, waitUntil } from '../_compat';
+import { setInputValue } from '../../buffer-refresh/dom-helpers';
+import { storagesStore, materialsStore } from '../_compat';
+import type { AssertFn } from '../shared-types';
+import { selectMaterial } from './cont-utils';
+
+interface Data {
+  from: string;
+  to: string;
+  ticker: string;
+  amount: number;
+}
+
+// Tracks the MTRA buffer command that is currently open (off-screen) so
+// consecutive MTRA_TRANSFER steps for the same origin/dest can skip the
+// full buffer-open navigation and reuse the already-open form.
+let lastMtraCommand: string | null = null;
+
+export function clearMtraBufferCache(): void {
+  lastMtraCommand = null;
+}
+
+export const MTRA_TRANSFER = act.addActionStep<Data>({
+  type: 'MTRA_TRANSFER',
+  preProcessData: data => ({ ...data, ticker: data.ticker.toUpperCase() }),
+  totalMaterials: data => ({ [data.ticker]: data.amount }),
+  description: data => {
+    const from = storagesStore.getById(data.from);
+    const to = storagesStore.getById(data.to);
+    const fromName = from ? serializeStorage(from) : 'NOT FOUND';
+    const toName = to ? serializeStorage(to) : 'NOT FOUND';
+    return `Transfer ${fixed0(data.amount)} ${data.ticker} from ${fromName} to ${toName}`;
+  },
+  execute: async ctx => {
+    const { data, log, setStatus, requestTile, waitAct, waitActionFeedback, complete, skip, fail } =
+      ctx;
+    const assert: AssertFn = ctx.assert;
+    const { ticker, amount } = data;
+
+    const from = storagesStore.getById(data.from);
+    assert(from, 'Origin inventory not found');
+    const to = storagesStore.getById(data.to);
+    assert(to, 'Destination inventory not found');
+
+    if (!from.items.find(x => x.quantity?.material.ticker === ticker)) {
+      log.warning(`No ${ticker} was transferred (not present in origin)`);
+      skip();
+      return;
+    }
+
+    if (amount <= 0) {
+      log.warning(`No ${ticker} was transferred (target amount is 0)`);
+      skip();
+      return;
+    }
+
+    const material = materialsStore.getByTicker(ticker);
+    assert(material, `Unknown material ${ticker}`);
+
+    // Check if at least one unit fits in the destination.
+    const epsilon = 0.000001;
+    const canFitWeight = to.weightCapacity - to.weightLoad - material.weight + epsilon >= 0;
+    const canFitVolume = to.volumeCapacity - to.volumeLoad - material.volume + epsilon >= 0;
+    if (!canFitWeight || !canFitVolume) {
+      log.warning(`No ${ticker} was transferred (no space)`);
+      skip();
+      return;
+    }
+
+    const command = `MTRA from-${from.id.substring(0, 8)} to-${to.id.substring(0, 8)}`;
+
+    let tile: import('../runtime-types').PrunTile;
+    if (lastMtraCommand === command) {
+      // Same origin/dest as the previous transfer — the MTRA form is still open
+      // off-screen, so skip the buffer-open navigation and the "Open …" ACT press.
+      const anchor = document.getElementById('container') as HTMLElement | null;
+      assert(anchor, 'MTRA buffer anchor (#container) not found');
+      tile = { anchor };
+      setStatus('Reusing MTRA buffer...');
+    } else {
+      const newTile = await requestTile(command);
+      if (!newTile) return;
+      tile = newTile;
+      lastMtraCommand = command;
+    }
+
+    setStatus('Setting up MTRA buffer...');
+    const container = await $(tile.anchor, C.MaterialSelector.container);
+
+    // Bring the buffer on-screen for material selection: WebKit won't focus or
+    // deliver input events to elements that are off-screen or visibility:hidden.
+    const bufContainer = tile.anchor as HTMLElement;
+    const prevVisibility = bufContainer.style.visibility;
+    const prevLeft = bufContainer.style.left;
+    bufContainer.style.visibility = 'visible';
+    bufContainer.style.left = '0px';
+    const ok = await selectMaterial(container!, ticker);
+
+    if (!ok) {
+      bufContainer.style.left = prevLeft;
+      bufContainer.style.visibility = prevVisibility;
+      fail(`Ticker ${ticker} not found in the material selector`);
+      return;
+    }
+
+    const sliderNumbers = _$$(tile.anchor, 'rc-slider-mark-text').map(x =>
+      Number(x.textContent ?? 0),
+    );
+    const maxAmount = Math.max(...sliderNumbers);
+    const allInputs = _$$<HTMLInputElement>(tile.anchor, 'input');
+    const amountInput = allInputs[1];
+    assert(amountInput !== undefined, 'Amount input not found');
+
+    if (amount > maxAmount) {
+      const leftover = amount - maxAmount;
+      log.warning(
+        `${fixed0(leftover)} ${ticker} not transferred ` +
+          `(${fixed0(maxAmount)} of ${fixed0(amount)} transferred)`,
+      );
+      if (maxAmount === 0) {
+        bufContainer.style.left = prevLeft;
+        bufContainer.style.visibility = prevVisibility;
+        skip();
+        return;
+      }
+    }
+    setInputValue(amountInput, Math.min(amount, maxAmount).toString());
+
+    // Find the Transfer button by text — C.Button.btn matches all APEX buttons
+    // in #container and the first one may not be the Transfer button.
+    const allBtns = _$$<HTMLElement>(tile.anchor, C.Button.btn);
+    const transferButton = allBtns.find(
+      btn => btn.textContent?.trim().toUpperCase() === 'TRANSFER',
+    );
+
+    await waitAct();
+
+    // Getter captures current state; Zustand store is updated by the message handler
+    // when the game server confirms the transfer.
+    const getDestinationAmount = () => {
+      const store = storagesStore.getById(data.to);
+      return (
+        store?.items
+          .filter(x => x.quantity !== null && x.quantity !== undefined)
+          .find(x => x.quantity!.material.ticker === ticker)?.quantity?.amount ?? 0
+      );
+    };
+    const currentAmount = getDestinationAmount();
+
+    // Keep buffer on-screen through click and feedback: clicking a hidden/off-screen
+    // button can cause unintended navigation or form submission on mobile WebKit.
+    assert(transferButton, 'Transfer button not found');
+    await clickElement(transferButton);
+    await waitActionFeedback(tile);
+    bufContainer.style.left = prevLeft;
+    bufContainer.style.visibility = prevVisibility;
+    await waitUntil(() => getDestinationAmount() !== currentAmount);
+
+    complete();
+  },
+});

--- a/lib/act/action-steps/OPEN_SFC.ts
+++ b/lib/act/action-steps/OPEN_SFC.ts
@@ -1,0 +1,36 @@
+// Ported from refined-prun src/features/XIT/ACT/action-steps/OPEN_SFC.ts.
+//
+// OPEN_SFC only fires when MTRA transfers material into a ship store (the
+// auto-SFC flow). Base resupply and repair flows never trigger it. The full
+// desktop implementation opens a split SFC tile and optionally sets a
+// destination — both require desktop-only Window.window / tile.frame APIs
+// that do not exist on mobile.
+//
+// Mobile: log an informational message and complete automatically so the user
+// knows to send the ship manually via APEX.
+
+import { act } from '../act-registry';
+import { useShipsStore } from '../../../stores/entities/ships';
+
+interface Data {
+  shipId: string;
+  destination?: string;
+  label?: string;
+}
+
+function buildMessage(data: Data): string {
+  const ship = useShipsStore.getState().getById(data.shipId);
+  const shipLabel = ship?.name ?? ship?.registration ?? data.shipId;
+  const label = data.label ?? 'Resupply';
+  return data.destination
+    ? `${label} loaded onto ${shipLabel}. Manually send to ${data.destination} in APEX.`
+    : `${label} loaded onto ${shipLabel}. Manually send ship in APEX.`;
+}
+
+export const OPEN_SFC = act.addActionStep<Data>({
+  type: 'OPEN_SFC',
+  description: data => buildMessage(data),
+  execute: async ctx => {
+    ctx.complete();
+  },
+});

--- a/lib/act/action-steps/cont-utils.ts
+++ b/lib/act/action-steps/cont-utils.ts
@@ -1,0 +1,102 @@
+// Ported from refined-prun src/features/XIT/ACT/action-steps/cont-utils.ts.
+// Only the selectMaterial helper is needed for BURNACT/REPAIRACT.
+// CONTD draft helpers (createNewDraft, setDraftNameAndPreamble, etc.) are
+// not ported — they are not used by the resupply or repair flows.
+//
+// Uses C, $, _$, _$$ as globals (populated by setupActGlobals() at runtime).
+
+import { focusElement, clickElement, sleep } from '../_compat';
+import { setInputValue } from '../../buffer-refresh/dom-helpers';
+
+/**
+ * Select a material by ticker inside a MaterialSelector component.
+ * Returns true on success, false if the ticker was not found.
+ */
+/** Convert PrunApi camelCase name to APEX display name: "advancedDeckElements" → "Advanced Deck Elements" */
+export function toDisplayName(name: string): string {
+  return name.replace(/([A-Z])/g, ' $1').replace(/^./, s => s.toUpperCase());
+}
+
+/**
+ * Select a material by ticker inside a MaterialSelector component.
+ * Types the ticker into the input (APEX accepts ticker or full name).
+ */
+export async function selectMaterial(container: Element, ticker: string): Promise<boolean> {
+  // Mobile APEX renders inputMobile; desktop renders input. Try mobile first.
+  let input = (await $(container, C.MaterialSelector.inputMobile, 1000)) as HTMLInputElement | null;
+  if (!input) {
+    input = (await $(container, C.MaterialSelector.input)) as HTMLInputElement | null;
+  }
+  if (!input) {
+    return false;
+  }
+
+  // suggestionsContainer may be absent on some APEX builds — handle gracefully
+  const suggestionsContainer = (await $(
+    container,
+    C.MaterialSelector.suggestionsContainer,
+    2000,
+  )) as HTMLElement | null;
+
+  // Focus via focus() — we know this works (activeElement confirmed in logs).
+  // click() loses focus to body so don't use it.
+  input.focus();
+  await sleep(100);
+
+  // Type character-by-character with full keyboard event sequence.
+  // APEX's autocomplete library listens for keydown/keyup to trigger suggestions;
+  // the native-setter + input-event approach used by setInputValue is not enough.
+  const nativeSetter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+
+  // Clear any stale value left from a previous selection (e.g., buffer reuse
+  // after a skipped step). Without this, chars append to the old ticker.
+  if (input.value) {
+    if (nativeSetter) nativeSetter.call(input, '');
+    else input.value = '';
+    input.dispatchEvent(new InputEvent('input', { bubbles: true }));
+    await sleep(50);
+  }
+
+  for (const char of ticker) {
+    input.dispatchEvent(new KeyboardEvent('keydown', { key: char, bubbles: true, cancelable: true }));
+    input.dispatchEvent(new KeyboardEvent('keypress', { key: char, bubbles: true, cancelable: true }));
+    if (nativeSetter) {
+      nativeSetter.call(input, input.value + char);
+    } else {
+      input.value += char;
+    }
+    input.dispatchEvent(new InputEvent('input', { data: char, inputType: 'insertText', bubbles: true }));
+    input.dispatchEvent(new KeyboardEvent('keyup', { key: char, bubbles: true, cancelable: true }));
+    await sleep(30);
+  }
+  // Suggestions dropdown may render in a React portal at document.body rather
+  // than inside the MaterialSelector container — search locally first (fast),
+  // then fall back to the full document.
+  let suggestionsList = await $(container, C.MaterialSelector.suggestionsList, 2000);
+  if (!suggestionsList) {
+    suggestionsList = await $(document.body, C.MaterialSelector.suggestionsList, 8000);
+  }
+  if (!suggestionsList) {
+    if (suggestionsContainer) suggestionsContainer.style.display = '';
+    return false;
+  }
+
+  if (suggestionsContainer) {
+    suggestionsContainer.style.display = 'none';
+  }
+
+  const entries = _$$(suggestionsList, C.MaterialSelector.suggestionEntry);
+  const match = entries.find(
+    (entry) => _$(entry, C.ColoredIcon.label)?.textContent === ticker,
+  );
+
+  if (!match) {
+    if (suggestionsContainer) suggestionsContainer.style.display = '';
+    return false;
+  }
+
+  await clickElement(match as HTMLElement);
+  if (suggestionsContainer) suggestionsContainer.style.display = '';
+  await sleep(200);
+  return true;
+}

--- a/lib/act/actions/cx-buy/config.ts
+++ b/lib/act/actions/cx-buy/config.ts
@@ -1,0 +1,6 @@
+// Ported verbatim from refined-prun src/features/XIT/ACT/actions/cx-buy/config.ts.
+
+export interface Config {
+  exchange?: string;
+  skip?: boolean;
+}

--- a/lib/act/actions/cx-buy/cx-buy.ts
+++ b/lib/act/actions/cx-buy/cx-buy.ts
@@ -1,0 +1,123 @@
+// Ported from refined-prun src/features/XIT/ACT/actions/cx-buy/cx-buy.ts.
+// Edit.vue and Configure.vue omitted — desktop-only UI, not needed to run.
+// userData.settings.noBuy replaced with useSettingsStore.getState().noBuy.
+
+import { act } from '../../act-registry';
+import { CXPO_BUY } from '../../action-steps/CXPO_BUY';
+import type { Config } from './config';
+import { fixed0, fixed02 } from '../../_compat';
+import { fillAmount } from './utils';
+import type { AssertFn } from '../../shared-types';
+import { configurableValue } from '../../shared-types';
+import { useSettingsStore } from '../../../../stores/settings';
+
+act.addAction<Config>({
+  type: 'CX Buy',
+  shortDescription: 'Buy materials from a commodity exchange',
+  description: (action, config) => {
+    if (!action.group || !action.exchange) {
+      return '--';
+    }
+    const exchange =
+      action.exchange === configurableValue
+        ? (config?.exchange ?? 'configured exchange')
+        : action.exchange;
+    return 'Buying group ' + action.group + ' from ' + exchange;
+  },
+  editComponent: undefined,
+  configureComponent: undefined,
+  needsConfigure: data => data.exchange === configurableValue,
+  isValidConfig: (data, config) =>
+    !!(data.skippable && config.skip) ||
+    data.exchange !== configurableValue ||
+    config.exchange !== undefined,
+  generateSteps: async ctx => {
+    const { data, config, state, log, fail, getMaterialGroup, emitStep } = ctx;
+
+    if (data.skippable && config.skip) {
+      return;
+    }
+    const assert: AssertFn = ctx.assert;
+    const allowUnfilled = data.allowUnfilled ?? false;
+    const buyPartial = data.buyPartial ?? false;
+
+    const materials = await getMaterialGroup(data.group);
+    assert(materials, 'Invalid material group');
+
+    const exchange = data.exchange === configurableValue ? config.exchange : data.exchange;
+    assert(exchange, 'Missing exchange');
+
+    // Subtract materials already in the CX warehouse from the buy list.
+    if ((data.useCXInv ?? true) && exchange) {
+      for (const mat of Object.keys(materials)) {
+        for (const CXMat of Object.keys(state.WAR[exchange] ?? {})) {
+          if (CXMat === mat) {
+            const used = Math.min(materials[mat], state.WAR[exchange][CXMat]);
+            materials[mat] -= used;
+            state.WAR[exchange][CXMat] -= used;
+            if (state.WAR[exchange][mat] <= 0) {
+              delete state.WAR[exchange][CXMat];
+            }
+          }
+        }
+        if (materials[mat] <= 0) {
+          delete materials[mat];
+        }
+      }
+    }
+
+    const noBuy = new Set(useSettingsStore.getState().noBuy);
+    for (const ticker of Object.keys(materials)) {
+      if (noBuy.has(ticker)) {
+        continue;
+      }
+      const amount = materials[ticker];
+      const priceLimit = data.priceLimits?.[ticker] ?? Infinity;
+      if (isNaN(priceLimit)) {
+        log.error('Non-numerical price limit on ' + ticker);
+        continue;
+      }
+
+      const cxTicker = `${ticker}.${exchange}`;
+      const filled = fillAmount(cxTicker, amount, priceLimit);
+      let bidAmount = amount;
+
+      if (filled && filled.amount < amount && !allowUnfilled) {
+        if (!buyPartial) {
+          let message = `Not enough materials on ${exchange} to buy ${fixed0(amount)} ${ticker}`;
+          if (isFinite(priceLimit)) {
+            message += ` with price limit ${fixed02(priceLimit)}/u`;
+          }
+          fail(message);
+          return;
+        }
+
+        const leftover = amount - filled.amount;
+        let message =
+          `${fixed0(leftover)} ${ticker} will not be bought on ${exchange} ` +
+          `(${fixed0(filled.amount)} of ${fixed0(amount)} available`;
+        if (isFinite(priceLimit)) {
+          message += ` with price limit ${fixed02(priceLimit)}/u`;
+        }
+        message += ')';
+        log.warning(message);
+        if (filled.amount === 0) {
+          continue;
+        }
+
+        bidAmount = filled.amount;
+      }
+
+      emitStep(
+        CXPO_BUY({
+          exchange,
+          ticker,
+          amount: bidAmount,
+          priceLimit,
+          buyPartial,
+          allowUnfilled,
+        }),
+      );
+    }
+  },
+});

--- a/lib/act/actions/cx-buy/utils.ts
+++ b/lib/act/actions/cx-buy/utils.ts
@@ -1,0 +1,36 @@
+// Ported verbatim from refined-prun
+// src/features/XIT/ACT/actions/cx-buy/utils.ts.
+// Imports adapted to APXM layout via ../../_compat.
+
+import { cxobStore, isFiniteOrder } from '../../_compat';
+
+export function fillAmount(cxTicker: string, amount: number, priceLimit: number) {
+  const orderBook = cxobStore.getByTicker(cxTicker);
+  if (!orderBook) {
+    return undefined;
+  }
+
+  const filled = {
+    amount: 0,
+    priceLimit: 0,
+    cost: 0,
+  };
+  const orders = orderBook.sellingOrders.slice().sort((a, b) => a.limit.amount - b.limit.amount);
+  for (const order of orders) {
+    const orderPrice = order.limit.amount;
+    if (priceLimit < orderPrice) {
+      break;
+    }
+    const orderAmount = isFiniteOrder(order) ? (order.amount as number) : Infinity;
+    const remaining = amount - filled.amount;
+    const filledByOrder = Math.min(remaining, orderAmount);
+    filled.priceLimit = orderPrice;
+    filled.amount += filledByOrder;
+    filled.cost += filledByOrder * orderPrice;
+    if (filled.amount === amount) {
+      break;
+    }
+  }
+
+  return filled;
+}

--- a/lib/act/actions/mtra/config.ts
+++ b/lib/act/actions/mtra/config.ts
@@ -1,0 +1,6 @@
+// Ported verbatim from refined-prun src/features/XIT/ACT/actions/mtra/config.ts.
+
+export interface Config {
+  origin?: string;
+  destination?: string;
+}

--- a/lib/act/actions/mtra/mtra.ts
+++ b/lib/act/actions/mtra/mtra.ts
@@ -1,0 +1,79 @@
+// Ported from refined-prun src/features/XIT/ACT/actions/mtra/mtra.ts.
+// Edit.vue and Configure.vue omitted — desktop-only UI, not needed to run.
+// generateSteps is pure TypeScript with no Vue; no changes needed there.
+
+import { act } from '../../act-registry';
+import { MTRA_TRANSFER } from '../../action-steps/MTRA_TRANSFER';
+import { OPEN_SFC } from '../../action-steps/OPEN_SFC';
+import { atSameLocation, deserializeStorage } from '../utils';
+import type { Config } from './config';
+import type { AssertFn } from '../../shared-types';
+import { configurableValue } from '../../shared-types';
+
+act.addAction<Config>({
+  type: 'MTRA',
+  shortDescription: 'Transfer materials between storages at the same location',
+  description: (action, config) => {
+    if (!action.group || !action.origin || !action.dest) {
+      return '--';
+    }
+    const origin =
+      action.origin === configurableValue
+        ? (config?.origin ?? 'configured location')
+        : action.origin;
+    const dest =
+      action.dest === configurableValue
+        ? (config?.destination ?? 'configured location')
+        : action.dest;
+    return `Transfer group [${action.group}] from ${origin} to ${dest}`;
+  },
+  editComponent: undefined,
+  configureComponent: undefined,
+  needsConfigure: data =>
+    data.origin === configurableValue || data.dest === configurableValue,
+  isValidConfig: (data, config) =>
+    (data.origin !== configurableValue || config.origin !== undefined) &&
+    (data.dest !== configurableValue || config.destination !== undefined),
+  generateSteps: async ctx => {
+    const { data, config, packageName, getMaterialGroup, getMaterialGroupPlanet, emitStep } = ctx;
+    const assert: AssertFn = ctx.assert;
+
+    const PRUNPLANNER_PACKAGES = [
+      'PRUNplanner Supply Cart',
+      'PRUNplanner Construct',
+      'PRUNplanner Transfer',
+      'PRUNplanner Burn Supply',
+    ];
+
+    const materials = await getMaterialGroup(data.group);
+    assert(materials, 'Invalid material group');
+
+    const serializedOrigin = data.origin === configurableValue ? config?.origin : data.origin;
+    const origin = deserializeStorage(serializedOrigin);
+    assert(origin, 'Invalid origin');
+
+    const serializedDest = data.dest === configurableValue ? config?.destination : data.dest;
+    const dest = deserializeStorage(serializedDest);
+    assert(dest, 'Invalid destination');
+
+    const isSameLocation = atSameLocation(origin, dest);
+    assert(isSameLocation, 'Origin and destination are not at the same location');
+
+    for (const ticker of Object.keys(materials)) {
+      emitStep(
+        MTRA_TRANSFER({
+          from: origin.id,
+          to: dest.id,
+          ticker,
+          amount: materials[ticker],
+        }),
+      );
+    }
+
+    if (dest.type === 'SHIP_STORE' && !PRUNPLANNER_PACKAGES.includes(packageName)) {
+      const planet = getMaterialGroupPlanet(data.group);
+      const label = packageName.startsWith('Repair') ? 'Repair' : 'Resupply';
+      emitStep(OPEN_SFC({ shipId: dest.addressableId, destination: planet, label }));
+    }
+  },
+});

--- a/lib/act/actions/utils.ts
+++ b/lib/act/actions/utils.ts
@@ -1,0 +1,143 @@
+// Ported from refined-prun src/features/XIT/ACT/actions/utils.ts.
+// Import paths and store calls adapted for APXM.
+
+import type { PrunApi } from '../../../types/prun-api';
+import { useSitesStore } from '../../../stores/entities/sites';
+import { useShipsStore } from '../../../stores/entities/ships';
+import { useWarehouseStore } from '../../../stores/warehouses';
+import { storagesStore, sitesStore } from '../_compat';
+import { getEntityDisplayName } from '../../address';
+
+// ---------------------------------------------------------------------------
+// serializeStorage — human-readable name for a Store
+// ---------------------------------------------------------------------------
+
+export function serializeStorage(storage: PrunApi.Store): string {
+  switch (storage.type) {
+    case 'STL_FUEL_STORE':
+      return (storage.name ?? storage.id) + ' STL Store';
+    case 'FTL_FUEL_STORE':
+      return (storage.name ?? storage.id) + ' FTL Store';
+    case 'SHIP_STORE':
+      return (storage.name ?? storage.id) + ' Cargo';
+    case 'STORE': {
+      const site = useSitesStore.getState().getAll().find(
+        (s) => s.siteId === storage.addressableId,
+      );
+      const label = site
+        ? getEntityDisplayName(site.address)
+        : (storage.name ?? storage.addressableId);
+      return label + ' Base';
+    }
+    case 'WAREHOUSE_STORE': {
+      const wh = useWarehouseStore.getState().warehouses.find(
+        (w) => w.warehouseId === storage.addressableId,
+      );
+      const label = wh?.stationNaturalId ?? wh?.systemNaturalId ?? storage.name ?? storage.addressableId;
+      return label + ' Warehouse';
+    }
+    default:
+      return storage.name ?? storage.id;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// deserializeStorage — reverse of serializeStorage
+// ---------------------------------------------------------------------------
+
+function extractName(name: string, suffix: string): string | undefined {
+  return name.endsWith(' ' + suffix) ? name.slice(0, -(suffix.length + 1)) : undefined;
+}
+
+export function deserializeStorage(serializedName: string | undefined): PrunApi.Store | undefined {
+  if (!serializedName) return undefined;
+
+  let name: string | undefined;
+
+  name = extractName(serializedName, 'Base');
+  if (name) {
+    const site = sitesStore.getByPlanetNaturalIdOrName(name);
+    return storagesStore.getByAddressableId(site?.siteId).find((x) => x.type === 'STORE');
+  }
+
+  name = extractName(serializedName, 'Warehouse');
+  if (name) {
+    const wh = useWarehouseStore.getState().getByEntityNaturalId(name);
+    if (!wh) return undefined;
+    return storagesStore.getByAddressableId(wh.warehouseId).find((s) => s.type === 'WAREHOUSE_STORE');
+  }
+
+  name = extractName(serializedName, 'Cargo');
+  if (name) {
+    return storagesStore.getByNameAndType(name, 'SHIP_STORE');
+  }
+
+  name = extractName(serializedName, 'FTL Store');
+  if (name) {
+    return storagesStore.getByNameAndType(name, 'FTL_FUEL_STORE');
+  }
+
+  name = extractName(serializedName, 'STL Store');
+  if (name) {
+    return storagesStore.getByNameAndType(name, 'STL_FUEL_STORE');
+  }
+
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Address comparison — used by atSameLocation
+// ---------------------------------------------------------------------------
+
+function getStoreAddress(store: PrunApi.Store): PrunApi.Address | undefined {
+  switch (store.type) {
+    case 'STORE': {
+      const site = useSitesStore.getState().getById(store.addressableId);
+      return site?.address;
+    }
+    case 'WAREHOUSE_STORE': {
+      const wh = useWarehouseStore.getState().warehouses.find(
+        (w) => w.warehouseId === store.addressableId,
+      );
+      if (!wh) return undefined;
+      const naturalId = wh.stationNaturalId ?? wh.systemNaturalId;
+      if (!naturalId) return undefined;
+      const lineType = wh.stationNaturalId ? 'STATION' : 'SYSTEM';
+      return {
+        lines: [{ type: lineType, entity: { id: naturalId, naturalId, name: naturalId } }],
+      } as PrunApi.Address;
+    }
+    case 'SHIP_STORE':
+    case 'STL_FUEL_STORE':
+    case 'FTL_FUEL_STORE': {
+      const ship = useShipsStore.getState().getById(store.addressableId);
+      return ship?.address ?? undefined;
+    }
+    default:
+      return undefined;
+  }
+}
+
+function isSameAddress(
+  a: PrunApi.Address | undefined,
+  b: PrunApi.Address | undefined,
+): boolean {
+  if (!a || !b) return false;
+  for (const lineA of a.lines) {
+    if (lineA.type !== 'PLANET' && lineA.type !== 'STATION') continue;
+    const entityA = (lineA as PrunApi.PlanetAddressLine | PrunApi.StationAddressLine).entity;
+    if (!entityA) continue;
+    for (const lineB of b.lines) {
+      if (lineB.type !== 'PLANET' && lineB.type !== 'STATION') continue;
+      const entityB = (lineB as PrunApi.PlanetAddressLine | PrunApi.StationAddressLine).entity;
+      if (!entityB) continue;
+      if (entityA.naturalId === entityB.naturalId) return true;
+    }
+  }
+  return false;
+}
+
+export function atSameLocation(storageA: PrunApi.Store, storageB: PrunApi.Store): boolean {
+  if (storageA === storageB) return false;
+  return isSameAddress(getStoreAddress(storageA), getStoreAddress(storageB));
+}

--- a/lib/act/ambient.d.ts
+++ b/lib/act/ambient.d.ts
@@ -1,0 +1,25 @@
+// Ambient declarations for refined-prun-style globals used by the ported
+// action-step execute() functions. setupActGlobals() (lib/act/globals-setup.ts)
+// must be called before any step runs to populate these on window.
+
+declare const C: Record<string, Record<string, string>>;
+
+// Async: waits up to timeoutMs (default 10 s) for the first matching element;
+// resolves null on timeout. Signature must match select-dom.ts selectWait.
+declare function $<T extends HTMLElement = HTMLElement>(
+  root: Element | Document,
+  selector: string,
+  timeoutMs?: number,
+): Promise<T | null>;
+
+// Synchronous: returns first matching element or null.
+declare function _$<T extends HTMLElement = HTMLElement>(
+  root: Element | Document,
+  selector: string,
+): T | null;
+
+// Synchronous: returns all matching elements.
+declare function _$$<T extends HTMLElement = HTMLElement>(
+  root: Element | Document,
+  selector: string,
+): T[];

--- a/lib/act/globals-setup.ts
+++ b/lib/act/globals-setup.ts
@@ -1,0 +1,25 @@
+// Installs ACT global helpers on window so that action-step execute() functions
+// can use C, $, _$, _$$ without explicit imports — matching the refined-prun
+// global pattern declared in ambient.d.ts.
+//
+// Call setupActGlobals() once before any ActionRunner is created.
+// Subsequent calls are no-ops.
+
+import { C, loadPrunCss } from './prun-css';
+import { selectWait, selectOne, selectAll } from './select-dom';
+
+let installed = false;
+
+export function setupActGlobals(): void {
+  if (installed) return;
+  installed = true;
+
+  loadPrunCss();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const w = window as any;
+  w.C = C;
+  w.$ = selectWait;
+  w._$ = selectOne;
+  w._$$ = selectAll;
+}

--- a/lib/act/material-groups/repair/config.ts
+++ b/lib/act/material-groups/repair/config.ts
@@ -1,0 +1,7 @@
+// Ported verbatim from refined-prun src/features/XIT/ACT/material-groups/repair/config.ts.
+
+export interface Config {
+  planet: string;
+  days?: number;
+  advanceDays?: number;
+}

--- a/lib/act/material-groups/repair/repair.ts
+++ b/lib/act/material-groups/repair/repair.ts
@@ -1,0 +1,104 @@
+// Ported from refined-prun src/features/XIT/ACT/material-groups/repair/repair.ts.
+// Edit.vue and Configure.vue omitted — desktop-only UI.
+// Synchronous calculation; no Vue in generateMaterialBill.
+//
+// Store adaptations:
+//   sitesStore.getByPlanetNaturalIdOrName  → sitesStore from _compat
+//   getBuildingLastRepair(building)        → inlined (building.lastRepair?.timestamp ?? building.creationTime.timestamp)
+//   isRepairableBuilding(building)         → inlined (module.type === 'RESOURCES' || 'PRODUCTION')
+
+import { act } from '../../act-registry';
+import type { Config } from './config';
+import { sitesStore } from '../../_compat';
+import { configurableValue } from '../../shared-types';
+import type { PrunApi } from '../../../../types/prun-api';
+
+function getBuildingLastRepair(building: PrunApi.Platform): number {
+  return building.lastRepair?.timestamp ?? building.creationTime.timestamp;
+}
+
+function isRepairableBuilding(building: PrunApi.Platform): boolean {
+  return building.module.type === 'RESOURCES' || building.module.type === 'PRODUCTION';
+}
+
+act.addMaterialGroup<Config>({
+  type: 'Repair',
+  shortDescription: 'Calculate repair materials for aging buildings',
+  description: data => {
+    if (!data.planet) {
+      return '--';
+    }
+    const days = data.days;
+    const daysLabel = days === configurableValue ? '?' : days;
+    const daysPart = days !== undefined ? `older than ${daysLabel} day${days == 1 ? '' : 's'}` : '';
+    const advanceDays = data.advanceDays ?? 0;
+    const advanceLabel = advanceDays === configurableValue ? '?' : advanceDays;
+    return `Repair buildings on ${data.planet} ${daysPart} in ${advanceLabel} day${advanceDays == 1 ? '' : 's'}`;
+  },
+  editComponent: undefined,
+  configureComponent: undefined,
+  needsConfigure: data =>
+    data.planet === configurableValue ||
+    data.days === configurableValue ||
+    data.advanceDays === configurableValue,
+  isValidConfig: (data, config) =>
+    (data.planet !== configurableValue || config.planet !== undefined) &&
+    (data.days !== configurableValue || config.days !== undefined) &&
+    (data.advanceDays !== configurableValue || config.advanceDays !== undefined),
+  generateMaterialBill: async ({ data, config, log }) => {
+    if (!data.planet) {
+      log.error('Resupply planet is not configured');
+      return undefined;
+    }
+
+    const planet = data.planet === configurableValue ? config.planet : data.planet;
+    const site = sitesStore.getByPlanetNaturalIdOrName(planet);
+    if (!site?.platforms) {
+      log.error('Missing data on repair planet');
+      return undefined;
+    }
+
+    const rawDays = data.days === configurableValue ? config.days : data.days;
+    const rawAdvanceDays =
+      data.advanceDays === configurableValue ? config.advanceDays : data.advanceDays;
+    const days = typeof rawDays === 'number' ? rawDays : parseFloat(rawDays as string);
+    let advanceDays =
+      typeof rawAdvanceDays === 'number' ? rawAdvanceDays : parseFloat(rawAdvanceDays as string);
+    const threshold = isNaN(days) ? 0 : days;
+    advanceDays = isNaN(advanceDays) ? 0 : advanceDays;
+
+    const parsedGroup: Record<string, number> = {};
+    for (const building of site.platforms) {
+      if (!isRepairableBuilding(building)) {
+        continue;
+      }
+
+      const lastRepair = getBuildingLastRepair(building);
+      const date = (Date.now() - lastRepair) / 86400000;
+
+      if (date + advanceDays < threshold) {
+        continue;
+      }
+
+      const buildingMaterials: Record<string, number> = {};
+      for (const mat of building.reclaimableMaterials) {
+        buildingMaterials[mat.material.ticker] =
+          (buildingMaterials[mat.material.ticker] ?? 0) + mat.amount;
+      }
+      for (const mat of building.repairMaterials) {
+        buildingMaterials[mat.material.ticker] =
+          (buildingMaterials[mat.material.ticker] ?? 0) + mat.amount;
+      }
+
+      const adjustedDate = date + advanceDays;
+      for (const ticker of Object.keys(buildingMaterials)) {
+        const amount =
+          adjustedDate > 180
+            ? buildingMaterials[ticker]
+            : Math.ceil((buildingMaterials[ticker] * adjustedDate) / 180);
+        parsedGroup[ticker] = (parsedGroup[ticker] ?? 0) + amount;
+      }
+    }
+    return parsedGroup;
+  },
+});

--- a/lib/act/material-groups/resupply/bill.ts
+++ b/lib/act/material-groups/resupply/bill.ts
@@ -1,0 +1,71 @@
+// Ported verbatim from refined-prun
+// src/features/XIT/ACT/material-groups/resupply/bill.ts.
+// Imports adapted to APXM layout via ../../_compat.
+
+import {
+  calculatePlanetBurn,
+  sitesStore,
+  workforcesStore,
+  productionStore,
+  storagesStore,
+} from '../../_compat';
+import type { MaterialFilter } from './config';
+
+// Computes the resupply material bill for a given planet and day count.
+// Returns undefined when inputs are missing or when the site's burn data is
+// not yet loaded. Kept synchronous so it can be driven reactively from the
+// Configure window.
+export function computeResupplyBill(
+  data: UserData.MaterialGroupData,
+  planet: string | undefined,
+  days: number | undefined,
+  materialFilter?: MaterialFilter,
+): Record<string, number> | undefined {
+  if (!planet || days === undefined || isNaN(days)) {
+    return undefined;
+  }
+  const site = sitesStore.getByPlanetNaturalIdOrName(planet);
+  if (!site) {
+    return undefined;
+  }
+  const workforce = workforcesStore.getById(site.siteId)?.workforces;
+  const production = productionStore.getBySiteId(site.siteId);
+  if (workforce === undefined || production === undefined) {
+    return undefined;
+  }
+  const stores = storagesStore.getByAddressableId(site.siteId);
+
+  const filter = materialFilter ?? (data.consumablesOnly ? 'Workforce' : 'All');
+  const planetBurn = calculatePlanetBurn(
+    production,
+    workforce,
+    (data.useBaseInv ?? true) ? stores : undefined,
+  );
+
+  const exclusions = data.exclusions ?? [];
+  const bill: Record<string, number> = {};
+  for (const ticker of Object.keys(planetBurn)) {
+    if (exclusions.includes(ticker)) {
+      continue;
+    }
+    const matBurn = planetBurn[ticker];
+    // For filtered modes, only include materials with primary demand type.
+    // Still use full dailyAmount so cross-demand (e.g. a workforce consumable
+    // that is also a production input) is fully accounted for.
+    if (filter === 'Workforce' && matBurn.workforce === 0) {
+      continue;
+    }
+    if (filter === 'Production' && matBurn.input === 0) {
+      continue;
+    }
+    if (matBurn.dailyAmount >= 0) {
+      continue;
+    }
+    const consumed = days * -matBurn.dailyAmount;
+    const need = Math.max(0, Math.ceil(consumed - matBurn.inventory + 1));
+    if (need > 0) {
+      bill[ticker] = need;
+    }
+  }
+  return bill;
+}

--- a/lib/act/material-groups/resupply/config.ts
+++ b/lib/act/material-groups/resupply/config.ts
@@ -1,0 +1,9 @@
+// Ported from refined-prun src/features/XIT/ACT/material-groups/resupply/config.ts.
+
+export type MaterialFilter = 'All' | 'Workforce' | 'Production';
+
+export interface Config {
+  planet: string;
+  days?: number;
+  materialFilter?: MaterialFilter;
+}

--- a/lib/act/material-groups/resupply/resupply.ts
+++ b/lib/act/material-groups/resupply/resupply.ts
@@ -1,0 +1,71 @@
+// Ported from refined-prun src/features/XIT/ACT/material-groups/resupply/resupply.ts.
+// Edit.vue and Configure.vue omitted — desktop-only UI.
+//
+// Vue adaptation:
+//   computed(() => workforcesStore.getById(...))  → direct getter call
+//   computed(() => productionStore.getBySiteId(...)) → direct getter call
+//   watchWhile(toRef(() => ... === undefined))    → await waitUntil(() => ... !== undefined)
+//
+// In APXM the production store always returns an array (never undefined), so
+// the wait only needs to gate on workforce data arriving.
+
+import { act } from '../../act-registry';
+import type { Config } from './config';
+import { sitesStore, workforcesStore } from '../../_compat';
+import { configurableValue } from '../../shared-types';
+import { computeResupplyBill } from './bill';
+import { waitUntil } from '../../_compat';
+import { getEntityDisplayName } from '../../../address';
+
+act.addMaterialGroup<Config>({
+  type: 'Resupply',
+  shortDescription: 'Calculate consumables needed based on burn rate',
+  description: data => {
+    if (!data.planet || data.days === undefined) {
+      return '--';
+    }
+    const daysLabel = data.days === configurableValue ? '?' : data.days;
+    return `Resupply ${data.planet} with ${daysLabel} day${data.days == 1 ? '' : 's'} of supplies`;
+  },
+  editComponent: undefined,
+  configureComponent: undefined,
+  needsConfigure: data =>
+    data.planet === configurableValue || data.days === configurableValue,
+  isValidConfig: (data, config) =>
+    (data.planet !== configurableValue || config.planet !== undefined) &&
+    (data.days !== configurableValue || config.days !== undefined),
+  generateMaterialBill: async ({ data, config, log, setStatus }) => {
+    if (!data.planet) {
+      log.error('Missing resupply planet');
+    }
+    if (data.days === undefined) {
+      log.error('Missing resupply days');
+    }
+
+    const planet = data.planet === configurableValue ? config.planet : data.planet;
+    const days =
+      data.days === configurableValue
+        ? (config.days ?? 10)
+        : typeof data.days === 'number'
+          ? data.days
+          : parseFloat(data.days as string);
+
+    const site = sitesStore.getByPlanetNaturalIdOrName(planet);
+    if (!site) {
+      log.error(`Base is not present on ${data.planet}`);
+    }
+
+    if (!site || days === undefined || isNaN(days)) {
+      return undefined;
+    }
+
+    // Wait for live workforce data if it hasn't arrived from the game server yet.
+    if (workforcesStore.getById(site.siteId) === undefined) {
+      const name = getEntityDisplayName(site.address);
+      setStatus(`Loading ${name} burn data...`);
+      await waitUntil(() => workforcesStore.getById(site.siteId) !== undefined);
+    }
+
+    return computeResupplyBill(data, planet, days, config.materialFilter);
+  },
+});

--- a/lib/act/prun-css.ts
+++ b/lib/act/prun-css.ts
@@ -1,0 +1,51 @@
+// Dynamically builds the C object from APEX's injected CSS stylesheets.
+// Ported from refined-prun src/infrastructure/prun-ui/prun-css.ts.
+// Vue reactivity removed; plain MutationObserver used instead.
+//
+// APEX injects <style data-source="prun"> elements whose CSS contains
+// CSS-module hash selectors like ".Button__btn___UJGZ1b7". This module
+// parses those rules and populates C so action steps can write
+// C.Button.btn instead of hardcoding the hash string.
+
+export const C: Record<string, Record<string, string>> = {};
+
+const processedStylesheets = new WeakSet<HTMLStyleElement>();
+
+function camelize(s: string): string {
+  return s.replace(/-./g, x => x[1].toUpperCase());
+}
+
+function processStylesheet(style: HTMLStyleElement): void {
+  if (style.dataset.source !== 'prun' || processedStylesheets.has(style)) {
+    return;
+  }
+  processedStylesheets.add(style);
+
+  const rules = style.sheet?.cssRules;
+  if (!rules) return;
+
+  for (let i = 0; i < rules.length; i++) {
+    const rule = rules.item(i) as CSSStyleRule;
+    const selector = rule?.selectorText;
+    if (!selector?.includes('___')) continue;
+
+    const matches = selector.match(/[\w-]+__[\w-]+___[\w-]+/g);
+    for (const match of matches ?? []) {
+      // Strip leading '.' if present (selector may be '.Foo__bar___HASH')
+      const cssClass = match.replace(/^\./, '');
+      const parts = cssClass.replace('__', '.').replace('___', '.').split('.');
+      const parent = camelize(parts[0]);
+      if (!parent) continue;
+      const child = camelize(parts[1]);
+      if (!C[parent]) C[parent] = {};
+      if (!C[parent][child]) C[parent][child] = cssClass;
+    }
+  }
+}
+
+export function loadPrunCss(): void {
+  document.head.querySelectorAll<HTMLStyleElement>('style').forEach(processStylesheet);
+  new MutationObserver(() => {
+    document.head.querySelectorAll<HTMLStyleElement>('style').forEach(processStylesheet);
+  }).observe(document.head, { childList: true });
+}

--- a/lib/act/register-all.ts
+++ b/lib/act/register-all.ts
@@ -1,0 +1,16 @@
+// Import every ACT registration module so they self-register via side-effects.
+// Import this once (e.g. at the top of BurnActView / RepairActView) before
+// creating any ActionRunner.
+
+// Action steps
+import './action-steps/MTRA_TRANSFER';
+import './action-steps/CXPO_BUY';
+import './action-steps/OPEN_SFC';
+
+// Actions
+import './actions/mtra/mtra';
+import './actions/cx-buy/cx-buy';
+
+// Material groups
+import './material-groups/resupply/resupply';
+import './material-groups/repair/repair';

--- a/lib/act/runner/action-runner.ts
+++ b/lib/act/runner/action-runner.ts
@@ -1,0 +1,123 @@
+// Ported from refined-prun src/features/XIT/ACT/runner/action-runner.ts.
+// refined-prun's desktop TileAllocator is replaced by the mobile buffer
+// navigator: the step machine opens each buffer through openMobileBuffer()
+// directly, so the runner no longer threads a tile allocator or stub.
+
+import { act } from '../act-registry';
+import { deepToRaw, fixed02, materialsStore } from '../_compat';
+import { Logger, type LogPart } from './logger';
+import { StepMachine } from './step-machine';
+import { StepGenerator } from './step-generator';
+import { ActionPackageConfig, ActionStep } from '../shared-types';
+
+interface ActionRunnerOptions {
+  log: Logger;
+  onBufferSplit: () => void;
+  onStart: () => void;
+  onEnd: () => void;
+  onStatusChanged: (status: string, keepReady?: boolean) => void;
+  onActReady: () => void;
+}
+
+export class ActionRunner {
+  private readonly stepGenerator: StepGenerator;
+  private stepMachine?: StepMachine;
+
+  constructor(private options: ActionRunnerOptions) {
+    this.stepGenerator = new StepGenerator(options);
+  }
+
+  get log() {
+    return this.options.log;
+  }
+
+  get isRunning() {
+    return this.stepMachine?.isRunning ?? false;
+  }
+
+  async preview(pkg: UserData.ActionPackageData, config: ActionPackageConfig) {
+    if (this.isRunning) {
+      this.log.error('Action Package is already running');
+      return;
+    }
+    // Create a copy to prevent changes during execution.
+    const copy = structuredClone(deepToRaw(pkg));
+    const { steps, fail } = await this.stepGenerator.generateSteps(copy, config);
+    if (steps.length === 0) {
+      return;
+    }
+    this.log.info(formatTotals(steps));
+    if (fail) {
+      this.log.info('Generated steps for valid actions:');
+    }
+    for (const step of steps) {
+      const stepInfo = act.getActionStepInfo(step.type);
+      this.log.action(stepInfo.description(step));
+    }
+  }
+
+  async execute(pkg: UserData.ActionPackageData, config: ActionPackageConfig) {
+    if (this.isRunning) {
+      this.log.error('Action Package is already running');
+      return;
+    }
+    // Create a copy to prevent changes during execution.
+    const copy = structuredClone(deepToRaw(pkg));
+    const { steps, fail } = await this.stepGenerator.generateSteps(copy, config);
+    if (fail) {
+      this.log.error('Action Package execution failed');
+      return;
+    }
+    this.log.info('Action Package execution started');
+    this.log.info(formatTotals(steps));
+    this.stepMachine = new StepMachine(steps, this.options);
+    this.stepMachine.start();
+  }
+
+  act() {
+    this.stepMachine?.act();
+    if (!this.stepMachine?.isRunning) {
+      this.stepMachine = undefined;
+    }
+  }
+
+  skip() {
+    this.stepMachine?.skip();
+    if (!this.stepMachine?.isRunning) {
+      this.stepMachine = undefined;
+    }
+  }
+
+  cancel() {
+    this.stepMachine?.cancel();
+    this.stepMachine = undefined;
+  }
+}
+
+function formatTotals(steps: ActionStep[]): LogPart[] {
+  const aggregated: Record<string, number> = {};
+  for (const step of steps) {
+    const info = act.getActionStepInfo(step.type);
+    const mats = info.totalMaterials?.(step);
+    if (mats) {
+      for (const [ticker, amount] of Object.entries(mats)) {
+        aggregated[ticker] = (aggregated[ticker] ?? 0) + amount;
+      }
+    }
+  }
+  let totalWeight = 0;
+  let totalVolume = 0;
+  for (const [ticker, amount] of Object.entries(aggregated)) {
+    const mat = materialsStore.getByTicker(ticker);
+    if (mat) {
+      totalWeight += mat.weight * amount;
+      totalVolume += mat.volume * amount;
+    }
+  }
+  return [
+    { text: 'Total Weight ' },
+    { text: `${fixed02(totalWeight)}t`, yellow: true },
+    { text: ', Total Volume ' },
+    { text: `${fixed02(totalVolume)}m³`, yellow: true },
+  ];
+}

--- a/lib/act/runner/logger.ts
+++ b/lib/act/runner/logger.ts
@@ -1,0 +1,59 @@
+// Ported verbatim from refined-prun src/features/XIT/ACT/runner/logger.ts.
+
+export type LogTag = null | 'INFO' | 'ACTION' | 'SUCCESS' | 'ERROR' | 'SKIP' | 'WARNING' | 'CANCEL';
+
+export type LogPart = { text: string; yellow?: boolean };
+export type LogContent = string | LogPart[];
+
+export class Logger {
+  constructor(public readonly logMessage: (tag: LogTag, msg: LogContent) => void) {}
+
+  label(msg: string) {
+    this.logMessage(null, msg);
+  }
+
+  info(msg: LogContent) {
+    this.logMessage('INFO', msg);
+  }
+
+  action(msg: string) {
+    this.logMessage('ACTION', msg);
+  }
+
+  success(msg: string) {
+    this.logMessage('SUCCESS', msg);
+  }
+
+  error(msg: string) {
+    this.logMessage('ERROR', msg);
+  }
+
+  skip(msg: string) {
+    this.logMessage('SKIP', msg);
+  }
+
+  warning(msg: string) {
+    this.logMessage('WARNING', msg);
+  }
+
+  cancel(msg: string) {
+    this.logMessage('CANCEL', msg);
+  }
+
+  runtimeError(e: unknown) {
+    console.error(e);
+    if (e instanceof Error) {
+      if (e.stack) {
+        for (const line of e.stack.split('\n')) {
+          this.error(line);
+        }
+      } else {
+        this.error(e.message);
+      }
+    } else {
+      this.error(e as string);
+    }
+    this.error(`Action Package execution failed due to a runtime error`);
+    this.error(`Please report this error to the extension developer`);
+  }
+}

--- a/lib/act/runner/step-generator.ts
+++ b/lib/act/runner/step-generator.ts
@@ -1,0 +1,182 @@
+// Ported from refined-prun src/features/XIT/ACT/runner/step-generator.ts.
+// Pure async; no Vue. Import paths updated for APXM; missing stores are
+// adapted via ../_compat.
+
+import {
+  ActionPackageConfig,
+  ActionStep,
+  configurableValue,
+} from '../shared-types';
+import { Logger } from './logger';
+import {
+  warehousesStore,
+  exchangesStore,
+  storagesStore,
+} from '../_compat';
+import { act } from '../act-registry';
+
+interface StepGeneratorOptions {
+  log: Logger;
+  onStatusChanged: (status: string) => void;
+}
+
+const AssertionError = new Error('Assertion failed');
+
+export class StepGenerator {
+  constructor(private options: StepGeneratorOptions) {}
+
+  get log() {
+    return this.options.log;
+  }
+
+  private groupPrices = new Map<string, Record<string, number>>();
+
+  async generateSteps(pkg: UserData.ActionPackageData, config: ActionPackageConfig) {
+    this.groupPrices.clear();
+    const state = generateState();
+    const steps = [] as ActionStep[];
+    let fail = false;
+    for (const action of pkg.actions) {
+      const info = act.getActionInfo(action.type);
+      if (!info) {
+        continue;
+      }
+      const actionConfig = (config.actions as unknown as Record<string, unknown>)[action.name!] ?? {};
+      const log = new Logger((tag, message) =>
+        this.log.logMessage(
+          tag,
+          typeof message === 'string' ? `[${action.name}] ${message}` : message,
+        ),
+      );
+      try {
+        await info.generateSteps({
+          data: action,
+          config: actionConfig,
+          packageName: pkg.global.name,
+          log,
+          fail: message => {
+            if (message) {
+              log.error(message);
+            }
+            fail = true;
+          },
+          assert: (condition, message) => {
+            if (!condition) {
+              log.error(message);
+              throw AssertionError;
+            }
+          },
+          emitStep: step => steps.push(step),
+          getMaterialGroup: async name => await this.getMaterialGroup(pkg, config, name),
+          getMaterialGroupPrices: name => (name ? this.groupPrices.get(name) : undefined),
+          getMaterialGroupPlanet: name => this.getMaterialGroupPlanet(pkg, config, name),
+          state,
+        });
+      } catch (e) {
+        if (e !== AssertionError) {
+          this.log.runtimeError(e);
+        }
+        fail = true;
+      }
+
+      if (fail) {
+        break;
+      }
+    }
+    if (steps.length === 0) {
+      this.log.error('No actions were generated');
+      fail = true;
+    }
+    return { steps, fail };
+  }
+
+  private getMaterialGroupPlanet(
+    pkg: UserData.ActionPackageData,
+    config: ActionPackageConfig,
+    name: string | undefined,
+  ): string | undefined {
+    if (!name) {
+      this.log.error('Missing material group');
+      return undefined;
+    }
+    const group = pkg.groups.find(x => x.name === name);
+    if (!group) {
+      this.log.error('Unrecognized material group');
+      return undefined;
+    }
+    const planet = group.planet;
+    if (!planet) {
+      this.log.warning(`Material group [${name}] has no planet configured; auto SFC will not run`);
+      return undefined;
+    }
+    if (planet === configurableValue) {
+      const groupConfig = (config.materialGroups as unknown as Record<string, unknown>)[name] ?? {};
+      const configuredPlanet = (groupConfig as { planet?: string }).planet;
+      if (!configuredPlanet) {
+        this.log.error(`Material group [${name}] planet not configured`);
+        return undefined;
+      }
+      return configuredPlanet;
+    }
+    return planet;
+  }
+
+  private async getMaterialGroup(
+    pkg: UserData.ActionPackageData,
+    config: ActionPackageConfig,
+    name: string | undefined,
+  ) {
+    if (!name) {
+      this.log.error('Missing material group');
+      return undefined;
+    }
+    const group = pkg.groups.find(x => x.name === name);
+    if (!group) {
+      this.log.error('Unrecognized material group');
+      return undefined;
+    }
+
+    const info = act.getMaterialGroupInfo(group.type);
+    if (!info) {
+      this.log.error('Unrecognized material group type');
+      return undefined;
+    }
+
+    this.options.onStatusChanged(`Generating material bill for ${group.name}...`);
+    const groupConfig = (config.materialGroups as unknown as Record<string, unknown>)[name!] ?? {};
+    return await info.generateMaterialBill({
+      data: group,
+      config: groupConfig,
+      log: new Logger((tag, message) =>
+        this.log.logMessage(
+          tag,
+          typeof message === 'string' ? `[${group.name}] ${message}` : message,
+        ),
+      ),
+      setStatus: status => this.options.onStatusChanged(status),
+      setPrices: prices => this.groupPrices.set(name!, prices),
+    });
+  }
+}
+
+function generateState() {
+  const war = {} as Record<string, Record<string, number>>;
+  for (const ticker of ['AI1', 'CI1', 'IC1', 'NC1']) {
+    war[ticker] = {};
+    const naturalId = exchangesStore.getNaturalIdFromCode(ticker);
+    const warehouse = warehousesStore.getByEntityNaturalId(naturalId);
+    const inv = storagesStore.getById(warehouse?.storeId);
+
+    if (inv) {
+      for (const mat of inv.items) {
+        const quantity = mat.quantity;
+        if (quantity) {
+          war[ticker][quantity.material.ticker] = quantity.amount;
+        }
+      }
+    }
+  }
+  return {
+    WAR: war,
+  };
+}

--- a/lib/act/runner/step-machine.ts
+++ b/lib/act/runner/step-machine.ts
@@ -1,0 +1,287 @@
+// Ported from refined-prun src/features/XIT/ACT/runner/step-machine.ts.
+// Promises only. TileAllocator is replaced by the mobile buffer navigator:
+// requestBuffer() opens an APEX buffer via openMobileBuffer() and hands the
+// action step an anchor (#container) to scope its DOM queries against.
+
+import { act } from '../act-registry';
+import { ActionStep } from '../shared-types';
+import { Logger } from './logger';
+import { clickElement, sleep } from '../_compat';
+import type { PrunTile } from '../runtime-types';
+import { openMobileBuffer, closeMobileBuffer } from '../../mobile-buffer-navigator';
+import { clearMtraBufferCache } from '../action-steps/MTRA_TRANSFER';
+import { useSettingsStore } from '../../../stores/settings';
+
+interface StepMachineOptions {
+  log: Logger;
+  onBufferSplit: () => void;
+  onStart: () => void;
+  onEnd: () => void;
+  onStatusChanged: (status: string, keepReady?: boolean) => void;
+  onActReady: () => void;
+}
+
+const AssertionError = new Error('Assertion failed');
+
+export class StepMachine {
+  private next?: ActionStep;
+  private nextAct?: () => void;
+
+  constructor(
+    private steps: ActionStep[],
+    private options: StepMachineOptions,
+  ) {}
+
+  get isRunning() {
+    return this.next !== undefined;
+  }
+
+  get log() {
+    return this.options.log;
+  }
+
+  start() {
+    this.options.onStart();
+    void this.startNext();
+  }
+
+  act() {
+    if (!this.ensureRunning()) {
+      return;
+    }
+    const nextAct = this.nextAct;
+    this.nextAct = undefined;
+    nextAct?.();
+  }
+
+  skip() {
+    if (!this.ensureRunning()) {
+      return;
+    }
+    const next = this.next;
+    if (!next) {
+      return;
+    }
+    const info = act.getActionStepInfo(next.type);
+    this.log.skip(info.description(next));
+    this.nextAct = undefined;
+    void this.startNext();
+  }
+
+  cancel() {
+    if (!this.ensureRunning()) {
+      return;
+    }
+    this.log.cancel('Action Package execution canceled');
+    this.stop();
+  }
+
+  stop() {
+    this.next = undefined;
+    this.nextAct = undefined;
+    // Reset the MTRA buffer cache so a fresh run never skips the open step.
+    clearMtraBufferCache();
+    // Close any open buffer and restore APEX before signalling the end.
+    void closeMobileBuffer();
+    this.options.onEnd();
+  }
+
+  private async startNext() {
+    if (this.steps.length === 0) {
+      this.log.success('Action Package execution completed');
+      this.stop();
+      return;
+    }
+    const next = this.steps.shift()!;
+    this.next = next;
+    const info = act.getActionStepInfo(next.type);
+    let description: string | undefined;
+    const log = this.options.log;
+    try {
+      await info.execute({
+        data: next,
+        log,
+        setStatus: status => this.options.onStatusChanged(status),
+        waitAct: async status => {
+          status ??= description ?? info.description(next);
+          await this.waitAct(status);
+        },
+        waitActionFeedback: async tile => {
+          // Read at use time so a settings change mid-run takes effect on the
+          // next step. Default false: the user taps APEX's CONFIRM themselves
+          // (action-authorisation rule); auto-click is opt-in.
+          const autoConfirm = useSettingsStore.getState().autoConfirm;
+          this.options.onStatusChanged(
+            autoConfirm
+              ? 'Waiting for action feedback...'
+              : 'Waiting for action feedback (confirm in APEX if prompted)...',
+          );
+          const error = await waitActionFeedback(tile, autoConfirm);
+          if (error) {
+            log.error(error);
+            log.error(description ?? info.description(next));
+            log.error('Action Package execution failed');
+            this.stop();
+            return;
+          }
+        },
+        cacheDescription: () => {
+          description = info.description(next);
+          this.options.onStatusChanged(description, true);
+        },
+        complete: async () => {
+          // Wait a moment to allow data to update.
+          await sleep(0);
+          log.success(description ?? info.description(next));
+          void this.startNext();
+        },
+        skip: () => this.skip(),
+        fail: message => {
+          if (message) {
+            log.error(message);
+          }
+          log.error('Action Package execution failed');
+          this.stop();
+          return;
+        },
+        assert: (condition, message) => {
+          if (!condition) {
+            log.error(message);
+            throw AssertionError;
+          }
+        },
+        requestTile: async command => await this.requestBuffer(command),
+      });
+    } catch (e) {
+      if (e !== AssertionError) {
+        log.runtimeError(e);
+      }
+      this.stop();
+    }
+  }
+
+  private async requestBuffer(command: string): Promise<PrunTile | undefined> {
+    await this.waitAct(`Open ${command}`);
+    this.options.onStatusChanged(`Opening ${command}...`);
+    const opened = await openMobileBuffer(command);
+    const anchor = document.getElementById('container');
+    if (!opened || !anchor) {
+      this.log.error(`Failed to open ${command}`);
+      this.stop();
+      return undefined;
+    }
+    return { anchor };
+  }
+
+  private async waitAct(status: string) {
+    this.options.onStatusChanged(status);
+    this.options.onActReady();
+    await new Promise<void>(resolve => (this.nextAct = resolve));
+  }
+
+  private ensureRunning() {
+    if (!this.isRunning) {
+      this.log.error('Action Package is not running');
+    }
+    return this.isRunning;
+  }
+}
+
+async function waitActionFeedback(
+  tile: PrunTile,
+  autoConfirm: boolean,
+): Promise<string | undefined> {
+  const overlay = await $(tile.anchor, C.ActionFeedback.overlay);
+  if (!overlay) {
+    return 'Action feedback overlay did not appear';
+  }
+  await waitActionProgress(overlay);
+  if (overlay.classList.contains(C.ActionConfirmationOverlay.container)) {
+    if (autoConfirm) {
+      const confirm = _$$(overlay, C.Button.btn)[1];
+      if (confirm === undefined) {
+        return 'Confirmation overlay is missing confirm button';
+      }
+      await clickElement(confirm);
+    } else {
+      // Manual confirm (the default): the user must tap APEX's CONFIRM
+      // themselves. The buffer may be parked off-screen (openMobileBuffer
+      // hides #container — CXPO leaves it hidden), so bring it on-screen for
+      // the tap and restore afterwards. MTRA already shows the container, in
+      // which case this save/restore is a no-op.
+      const anchor = tile.anchor;
+      const prev = { visibility: anchor.style.visibility, left: anchor.style.left };
+      anchor.style.visibility = 'visible';
+      anchor.style.left = '0px';
+      try {
+        await waitConfirmationResolved(overlay);
+      } finally {
+        anchor.style.left = prev.left;
+        anchor.style.visibility = prev.visibility;
+      }
+    }
+    await waitActionProgress(overlay);
+  }
+  if (overlay.classList.contains(C.ActionFeedback.success)) {
+    await clickElement(overlay);
+    return;
+  }
+  if (overlay.classList.contains(C.ActionFeedback.error)) {
+    const message = _$(overlay, C.ActionFeedback.message)?.textContent;
+    const dismiss = _$(overlay, C.ActionFeedback.dismiss)?.textContent;
+    return dismiss ? message?.replace(dismiss, '') ?? undefined : message ?? undefined;
+  }
+
+  return 'Unknown action feedback overlay';
+}
+
+// Manual-confirm wait: resolves when the overlay leaves the confirmation
+// state. Two exits: (a) the overlay's own classList changes — after the user
+// taps CONFIRM, APEX transitions the same element through progress to
+// success/error, exactly the transition the auto-click path observes; or
+// (b) the overlay is detached — the user tapped CANCEL or APEX dismissed it
+// (a cancel then falls through the success/error checks and fails the step).
+// No timeout: like waitAct(), a human decision is unbounded.
+function waitConfirmationResolved(overlay: HTMLElement): Promise<void> {
+  if (!overlay.classList.contains(C.ActionConfirmationOverlay.container) || !overlay.isConnected) {
+    return Promise.resolve();
+  }
+  return new Promise<void>(resolve => {
+    const done = () => {
+      attrObserver.disconnect();
+      removalObserver.disconnect();
+      resolve();
+    };
+    const attrObserver = new MutationObserver(() => {
+      if (!overlay.classList.contains(C.ActionConfirmationOverlay.container)) {
+        done();
+      }
+    });
+    attrObserver.observe(overlay, { attributes: true, attributeFilter: ['class'] });
+    // A class observer never fires on node removal — watch the parent tree.
+    const removalObserver = new MutationObserver(() => {
+      if (!overlay.isConnected) {
+        done();
+      }
+    });
+    removalObserver.observe(overlay.parentElement ?? document.body, {
+      childList: true,
+      subtree: true,
+    });
+  });
+}
+
+async function waitActionProgress(overlay: HTMLElement) {
+  if (!overlay.classList.contains(C.ActionFeedback.progress)) {
+    return;
+  }
+  await new Promise<void>(resolve => {
+    const mutationObserver = new MutationObserver(() => {
+      if (!overlay.classList.contains(C.ActionFeedback.progress)) {
+        mutationObserver.disconnect();
+        resolve();
+      }
+    });
+    mutationObserver.observe(overlay, { attributes: true });
+  });
+}

--- a/lib/act/runtime-types.ts
+++ b/lib/act/runtime-types.ts
@@ -1,0 +1,11 @@
+// Runtime context handed to ACT action steps so they can scope DOM queries.
+//
+// refined-prun's desktop PrunTile is a floating tile/window. Mobile APXM has no
+// tiles: every buffer opens inside #container, so the "tile" an action step
+// receives is simply an anchor element it scopes its DOM queries against.
+
+export interface PrunTile {
+  // The DOM subtree the action step scopes its queries to. On mobile APXM this
+  // is always #container — the single buffer host opened by openMobileBuffer.
+  anchor: HTMLElement;
+}

--- a/lib/act/select-dom.ts
+++ b/lib/act/select-dom.ts
@@ -1,0 +1,56 @@
+// DOM selector helpers matching refined-prun's $ / _$ / _$$ interface.
+// Ported from refined-prun src/utils/select-dom.ts.
+//
+// Uses getElementsByClassName (live HTMLCollection) for CSS-module class names
+// and getElementsByTagName for HTML tag names — same strategy as rprun so that
+// C.* selectors and plain element tags both work without querySelector overhead.
+
+import { waitForElement } from '../buffer-refresh/dom-helpers';
+
+const TAG_NAMES = new Set([
+  'div', 'input', 'span', 'button', 'select', 'form',
+  'li', 'ul', 'ol', 'table', 'tr', 'td', 'th',
+  'h1', 'h2', 'h3', 'h4', 'p', 'a', 'label',
+  'textarea', 'option', 'style', 'progress',
+]);
+
+function getCollection<T extends Element>(
+  root: Element | Document,
+  selector: string,
+): HTMLCollectionOf<T> {
+  if (TAG_NAMES.has(selector)) {
+    return root.getElementsByTagName(selector) as HTMLCollectionOf<T>;
+  }
+  return root.getElementsByClassName(selector) as HTMLCollectionOf<T>;
+}
+
+/** Synchronous — returns first matching element or null. */
+export function selectOne<T extends HTMLElement = HTMLElement>(
+  root: Element | Document,
+  selector: string,
+): T | null {
+  const col = getCollection<T>(root, selector);
+  return col.length > 0 ? col[0] : null;
+}
+
+/** Synchronous — returns all matching elements. */
+export function selectAll<T extends HTMLElement = HTMLElement>(
+  root: Element | Document,
+  selector: string,
+): T[] {
+  return Array.from(getCollection<T>(root, selector));
+}
+
+/**
+ * Async — waits up to timeoutMs for the element to appear and returns it,
+ * or null if the timeout expires. Callers that receive null will naturally
+ * produce a TypeError when they access properties on it; the step-machine's
+ * try-catch handles those as step failures.
+ */
+export async function selectWait<T extends HTMLElement = HTMLElement>(
+  root: Element | Document,
+  selector: string,
+  timeoutMs = 10000,
+): Promise<T | null> {
+  return waitForElement(() => selectOne<T>(root, selector), timeoutMs);
+}

--- a/lib/act/shared-types.ts
+++ b/lib/act/shared-types.ts
@@ -1,0 +1,65 @@
+// Ported verbatim from refined-prun src/features/XIT/ACT/shared-types.ts
+// Import path updated for APXM layout.
+// Vue's `Component` type is intentionally not referenced — the registry now
+// stores generic editor handles instead.
+
+import { Logger } from './runner/logger';
+import type { PrunTile } from './runtime-types';
+
+export interface ActionPackageConfig {
+  materialGroups: Record<string, unknown>[];
+  actions: Record<string, unknown>[];
+}
+
+export interface ActionStep {
+  type: string;
+}
+
+export interface ActionRunnerContext<T> {
+  data: T;
+  log: Logger;
+}
+
+export interface MaterialGroupGenerateContext<TConfig>
+  extends ActionRunnerContext<UserData.MaterialGroupData> {
+  config: TConfig;
+  setStatus: (status: string) => void;
+  setPrices: (prices: Record<string, number>) => void;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AssertFn = (condition: any, message: string) => asserts condition;
+
+export interface ActionStepGenerateContext<TConfig>
+  extends ActionRunnerContext<UserData.ActionData> {
+  config: TConfig;
+  packageName: string;
+  fail: (message?: string) => void;
+  assert: AssertFn;
+  getMaterialGroup: (name: string | undefined) => Promise<Record<string, number> | undefined>;
+  getMaterialGroupPrices: (name: string | undefined) => Record<string, number> | undefined;
+  getMaterialGroupPlanet: (name: string | undefined) => string | undefined;
+  emitStep: (step: ActionStep) => void;
+  state: {
+    WAR: {
+      [exchange: string]: {
+        [mat: string]: number;
+      };
+    };
+  };
+}
+
+export interface ActionStepExecuteContext<T> extends ActionRunnerContext<T> {
+  setStatus: (status: string) => void;
+  waitAct: (status?: string) => Promise<void>;
+  waitActionFeedback: (tile: PrunTile) => Promise<void>;
+  cacheDescription: () => void;
+  complete: () => void;
+  skip: () => void;
+  fail: (message?: string) => void;
+  assert: AssertFn;
+  requestTile: (Command: string) => Promise<PrunTile | undefined>;
+}
+
+export const configurableValue = 'Configure on Execution';
+export const groupTargetPrefix = 'group:';

--- a/lib/act/user-data.types.d.ts
+++ b/lib/act/user-data.types.d.ts
@@ -1,0 +1,63 @@
+// Ported from refined-prun src/store/user-data.types.d.ts
+// ACT-relevant subset only. Kept as a global `UserData` namespace to mirror the
+// rprun source so the ported runner files match verbatim.
+
+declare namespace UserData {
+  export type Exchange = 'AI1' | 'CI1' | 'CI2' | 'IC1' | 'NC1' | 'NC2';
+
+  interface ActionPackageData {
+    groups: MaterialGroupData[];
+    actions: ActionData[];
+    global: {
+      name: string;
+    };
+  }
+
+  type MaterialGroupType = 'Manual' | 'Resupply' | 'Repair' | 'Paste';
+
+  interface MaterialGroupData {
+    type: MaterialGroupType;
+    name?: string;
+    days?: number | string;
+    advanceDays?: number | string;
+    planet?: string;
+    useBaseInv?: boolean;
+    materials?: Record<string, number>;
+    exclusions?: string[];
+    consumablesOnly?: boolean;
+  }
+
+  type ActionType = 'CX Buy' | 'MTRA' | 'Refuel' | 'CONT Ship' | 'CONT Trade';
+
+  interface ActionData {
+    type: ActionType;
+
+    name?: string;
+    group?: string;
+    skippable?: boolean;
+
+    allowUnfilled?: boolean;
+    buyPartial?: boolean;
+    exchange?: string;
+    useCXInv?: boolean;
+    priceLimits?: Record<string, number>;
+
+    buyMissingFuel?: boolean;
+
+    origin?: string;
+    dest?: string;
+
+    // CONT Ship specific
+    currency?: string;
+    contractNote?: string;
+    paymentPerTon?: number;
+    daysToFulfill?: number;
+    contOrigin?: string;
+    contDest?: string;
+    autoProvision?: boolean;
+
+    // CONT Trade specific
+    contTradeType?: 'BUYING' | 'SELLING';
+    contLocation?: string;
+  }
+}

--- a/lib/mobile-buffer-navigator.ts
+++ b/lib/mobile-buffer-navigator.ts
@@ -1,0 +1,179 @@
+/**
+ * Mobile buffer navigator for the ported ACT action runner.
+ *
+ * Desktop refined-prun opens a dedicated tile per buffer command via its
+ * TileAllocator. Mobile APEX has a single serial buffer and a hierarchical
+ * Stack UI, so this module drives the same Stack-navigation sequence the
+ * buffer-refresh engine already uses (see lib/buffer-refresh/engine.ts) to
+ * open an arbitrary buffer command, then waits for the buffer's form to render.
+ *
+ * Unlike the buffer-refresh engine, the navigator deliberately does NOT restore
+ * #container after a successful open: the buffer must stay open (off-screen) so
+ * the action runner can drive its form. restoreContainerStyles only happens in
+ * closeMobileBuffer (or after a failed open).
+ */
+
+import {
+  getContainer,
+  isAtStacksTopLevel,
+  navigateToStacksTopLevel,
+  saveContainerStyles,
+  applyRefreshHide,
+  restoreContainerStyles,
+  findBufferStackHeader,
+  findAddNewCardButton,
+  getCommandInput,
+  findCreateButton,
+  findCancelButton,
+  findCardByCommand,
+  setInputValue,
+  waitForElement,
+  type SavedStyles,
+} from './buffer-refresh/dom-helpers';
+import { warn, error } from './debug/logger';
+
+/** Timeout for each Stack-navigation DOM step. */
+const STEP_TIMEOUT_MS = 2000;
+
+/**
+ * Timeout for the buffer form to render after the card is clicked. Longer than
+ * a navigation step because opening a buffer can involve a server round-trip.
+ */
+const FORM_TIMEOUT_MS = 10000;
+
+/**
+ * Original #container styles, captured by the first openMobileBuffer call and
+ * held until closeMobileBuffer restores them. Subsequent openMobileBuffer calls
+ * (one per buffer command in a multi-step action package) must NOT recapture —
+ * that would record the already-hidden styles and leak them on restore.
+ */
+let savedStyles: SavedStyles | null = null;
+
+/**
+ * The buffer form sentinel. APEX renders a FormComponent container element
+ * inside an open buffer; its CSS-module class (FormComponent__containerActive
+ * / Passive / Command and the Mobile variants) is identical on mobile and
+ * desktop. Matching the class prefix avoids depending on a build-time hash map.
+ */
+function findBufferForm(): HTMLElement | null {
+  const container = getContainer();
+  if (!container) {
+    return null;
+  }
+  return container.querySelector<HTMLElement>('[class*="FormComponent__container"]');
+}
+
+/**
+ * Open an APEX buffer for `command` by driving the mobile Stack UI.
+ *
+ * Mirrors lib/buffer-refresh/engine.ts steps 1-8, then waits for the buffer's
+ * form to render. #container is hidden off-screen and stays hidden on success —
+ * the caller drives the form via the off-screen DOM and calls closeMobileBuffer
+ * when done. On failure the page is restored before returning false.
+ */
+export async function openMobileBuffer(command: string): Promise<boolean> {
+  const container = getContainer();
+  if (!container) {
+    error('openMobileBuffer: #container not found');
+    return false;
+  }
+
+  // Capture the pristine styles once. Later calls reuse them so a multi-buffer
+  // action package restores the real styles, not the off-screen ones.
+  if (savedStyles === null) {
+    savedStyles = saveContainerStyles(container);
+  }
+
+  try {
+    // Step 1-2: ensure we're at the Stacks top level (Buffer stack header visible).
+    if (!isAtStacksTopLevel()) {
+      const header = await waitForElement(findBufferStackHeader, STEP_TIMEOUT_MS);
+      if (!header) {
+        const reached = await navigateToStacksTopLevel(STEP_TIMEOUT_MS);
+        if (!reached) {
+          throw new Error('Could not navigate to Stacks top level');
+        }
+      }
+    }
+
+    // Step 3: hide #container off-screen (React keeps the DOM alive).
+    applyRefreshHide(container);
+
+    // Step 4: open the Buffer stack.
+    const stackHeader = findBufferStackHeader();
+    if (!stackHeader) {
+      throw new Error('Buffer stack header disappeared');
+    }
+    stackHeader.click();
+
+    // Step 5: add a new card.
+    const addButton = await waitForElement(findAddNewCardButton, STEP_TIMEOUT_MS);
+    if (!addButton) {
+      throw new Error('Add New Card button did not appear');
+    }
+    addButton.click();
+
+    // Step 6: enter the buffer command.
+    const input = await waitForElement(getCommandInput, STEP_TIMEOUT_MS);
+    if (!input) {
+      throw new Error('Command input did not appear');
+    }
+    setInputValue(input, command);
+
+    // Step 7: confirm card creation.
+    const createBtn = await waitForElement(findCreateButton, STEP_TIMEOUT_MS);
+    if (!createBtn) {
+      throw new Error('CREATE button did not appear');
+    }
+    createBtn.click();
+
+    // Step 8: open the freshly created card.
+    const card = await waitForElement(() => findCardByCommand(command), STEP_TIMEOUT_MS);
+    if (!card) {
+      throw new Error(`Card for "${command}" did not appear`);
+    }
+    card.click();
+
+    // Step 9: wait for the buffer's form to render.
+    const form = await waitForElement(findBufferForm, FORM_TIMEOUT_MS);
+    if (!form) {
+      throw new Error(`Buffer form for "${command}" did not render`);
+    }
+
+    return true;
+  } catch (err) {
+    error('openMobileBuffer:', err instanceof Error ? err.message : String(err));
+    // Restore the page so a failed open never leaves APEX hidden off-screen.
+    await closeMobileBuffer();
+    return false;
+  }
+}
+
+/**
+ * Close the current buffer: dismiss any leftover add-card dialog, navigate back
+ * to the Stacks top level, and restore #container to its pre-open styles.
+ *
+ * Safe to call when no buffer is open — every step is a no-op in that case.
+ */
+export async function closeMobileBuffer(): Promise<void> {
+  // Dismiss a half-finished add-card dialog left behind by a failed open.
+  const cancelBtn = findCancelButton();
+  if (cancelBtn) {
+    cancelBtn.click();
+  }
+
+  // Navigate back out of any open buffer to the Stacks top level.
+  if (!isAtStacksTopLevel()) {
+    const reached = await navigateToStacksTopLevel(STEP_TIMEOUT_MS);
+    if (!reached) {
+      warn('closeMobileBuffer: could not navigate back to Stacks top level');
+    }
+  }
+
+  // Restore #container so APEX is visible again.
+  const container = getContainer();
+  if (container && savedStyles) {
+    restoreContainerStyles(container, savedStyles);
+  }
+  savedStyles = null;
+}

--- a/stores/settings.ts
+++ b/stores/settings.ts
@@ -50,6 +50,11 @@ interface SettingsState {
    *  the persisted value at startup; production always starts 'manual'
    *  (the apxm_refresh URL param overrides either way). */
   refreshMode: RefreshMode;
+  /** When true the ACT step machine clicks APEX's post-ACT confirmation
+   *  overlay itself; when false (default) the user taps CONFIRM in APEX.
+   *  Opt-in per the action-authorisation rule. No UI yet — the Settings
+   *  toggle lands with the ACT views (#25 Phase D). */
+  autoConfirm: boolean;
 }
 
 interface SettingsActions {
@@ -63,6 +68,7 @@ interface SettingsActions {
   setStatusPanelOrder: (order: string[]) => void;
   setNoBuy: (tickers: string[]) => void;
   setRefreshMode: (mode: RefreshMode) => void;
+  setAutoConfirm: (enabled: boolean) => void;
   reset: () => void;
 }
 
@@ -89,6 +95,7 @@ const initialState: SettingsState = {
   statusPanelOrder: [...STATUS_PANEL_IDS],
   noBuy: [],
   refreshMode: 'manual',
+  autoConfirm: false,
 };
 
 // Check if browser storage API is available
@@ -187,6 +194,7 @@ export const useSettingsStore = create<SettingsStore>()(
 
       setNoBuy: (tickers) => set({ noBuy: tickers }),
       setRefreshMode: (mode) => set({ refreshMode: mode }),
+      setAutoConfirm: (enabled) => set({ autoConfirm: enabled }),
 
       reset: () => set(initialState),
     }),


### PR DESCRIPTION
## Summary

Ports the full ACT engine (~2,600 lines) from [jackinabox86's fork](https://github.com/jackinabox86/APXM) — his adaptation of refined-prun's XIT ACT feature (MIT, © 2025 Dan Pavlides; per-file `Ported from refined-prun` attribution headers kept verbatim). This is #25 Phase C: the engine lands complete and tested but nothing imports it at runtime — bundle size is unchanged. Phase D wires up `BurnActView`/`RepairActView`/`ActionRunnerPanel` and the Settings UI.

Credit to **@jackinabox86** for the working port this adopts, including the DOM gotchas and mobile workarounds already baked into it.

**Commit 1 — logic core:** `_compat` store adapter, act-registry, step generator, CX Buy / MTRA action logic, Resupply / Repair material groups, plus `settings.autoConfirm` (field only, default false).
**Commit 2 — DOM layer:** prun-css `C.*` resolver, select-dom globals, mobile buffer navigator, step machine, action runner, CXPO_BUY / MTRA_TRANSFER / OPEN_SFC action steps.

## Adaptations from the fork

- **Materials come from the FIO reference store** (`stores/reference.ts`) instead of the fork's WS-derived store — the engine only reads ticker/weight/volume, which `MaterialInfo` carries. Phase D should gate run-start on `useMaterialsStore.getState().fetched`.
- **`waitActionFeedback` is gated on `settings.autoConfirm` (default false).** The fork auto-clicked APEX's post-ACT confirmation overlay; per the action-authorisation ruling the default now brings the hidden buffer on-screen and waits for the user to tap CONFIRM themselves (observing the overlay's class transition). The auto-click survives only behind the opt-in flag; its Settings toggle ships with Phase D.
- Fixed two latent fork tsc errors (missing `WarehouseLocation` import; ambient `$` missing the `timeoutMs` param) — the fork built through them, main gates on `tsc --noEmit`.
- Stripped 13 debug `console.log`s; dropped port-session breadcrumb comments.

## Testing

- 580 tests pass (was 520): stage1 port + 7 new suites — `_compat` seam contract, step-generator WAR state, resupply/repair bill math, CX Buy fill/generateSteps (noBuy, warehouse inventory, partial fills), prun-css parsing, register-all (keeps the unreferenced engine executed under vitest), and the confirmation gate.
- Mutation-verified: broken ticker-case normalization and forced auto-confirm each fail their tests.
- `npx tsc --noEmit` clean; Chrome + Firefox builds green; bundle size unchanged (engine tree-shakes until Phase D).
- Device validation of the DOM layer (brittle APEX selectors, WebKit focus behaviour) is deliberately deferred to Phase D when the views make it drivable.

Part of #25. Related: #28 (the fork implements it — Phase D), #31 (`_compat` is the pure-core/adapter seam).

🤖 Generated with [Claude Code](https://claude.com/claude-code)