### PR TITLE
feat(contracts): one-tap ACCEPT/REJECT/FULFILL contract actions (#73)

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -33,6 +33,16 @@ input[type='number'] {
   overflow: visible !important;
 }
 
+/* Manual-confirm window for driven APEX actions: drop ONLY the background so
+   the user can see and tap APEX's confirmation dialog underneath. Height must
+   NOT collapse here — APEX's layout listeners treat host-height changes as a
+   navigation event and move the buffer stack mid-drive (CLAUDE.md gotcha).
+   The base :host pointer-events:none already passes taps through; the
+   ConfirmBar opts back in with pointer-events-auto. */
+:host(.act-confirm) {
+  background-color: transparent !important;
+}
+
 /* WXT container inside shadow root must fill the host. Also sets the overlay's
    default typeface — without this the UI inherits APEX's page font. Structure
    text defaults to Plex Sans; data elements opt into Plex Mono via `font-mono`. */

--- a/components/App.tsx
+++ b/components/App.tsx
@@ -7,6 +7,7 @@ import { UnavailableOverlay } from './UnavailableOverlay';
 
 export function App() {
   const apexVisible = useGameState((s) => s.apexVisible);
+  const actConfirmPending = useGameState((s) => s.actConfirmPending);
   const availability = useAvailabilityStatus();
   const interceptorConflict = useConnectionStore((s) => s.interceptorConflict);
   // APEX is showing its login screen — APXM stays dormant (host collapsed,
@@ -30,6 +31,16 @@ export function App() {
       }
     }
   }, [apexVisible, loginRequired]);
+
+  // Manual-confirm window (driven APEX action awaiting the user's CONFIRM):
+  // drop only the host BACKGROUND — never the height, which APEX's layout
+  // listeners would read as navigation mid-drive. AppShell hides the shell
+  // and shows the ConfirmBar; this effect just mirrors the state onto the
+  // host element the same way apex-visible is handled above.
+  useEffect(() => {
+    const host = document.querySelector('apxm-overlay') as HTMLElement | null;
+    host?.classList.toggle('act-confirm', actConfirmPending);
+  }, [actConfirmPending]);
 
   // Manage #container visibility and offset when toggling APEX.
   // When APEX visible: ensure display, offset below FloatingReturn bar.

--- a/components/contracts/ContractDetailView.tsx
+++ b/components/contracts/ContractDetailView.tsx
@@ -1,6 +1,8 @@
-import { MaterialTile } from '../shared';
+import { useState } from 'react';
+import { MaterialTile, btnPrimary, btnSecondary } from '../shared';
 import { useContractDetail, type ConditionPart, type ContractConditionDetail } from '../views/hooks';
 import { formatCreated, formatDeadline } from './format';
+import { runContractAction, type ContractActionTarget } from '../../lib/contract-actions';
 
 interface ContractDetailViewProps {
   contractId: string;
@@ -31,13 +33,21 @@ const midActionLabels: Partial<Record<ContractConditionDetail['status'], string>
   FULFILLMENT_ATTEMPTED: 'attempted',
 };
 
+interface ConditionBlockProps {
+  cond: ContractConditionDetail;
+  /** Fires the one-tap FULFILL passthrough for this condition (#73). */
+  onFulfill: () => void;
+  actionRunning: boolean;
+}
+
 /**
  * One condition block. Indicator + party on the top line, the description
- * beneath, and a dependency/mid-action hint. The per-condition FULFILL action
- * is intentionally NOT rendered yet — game-state-changing commands stay hidden
- * until the CONT-buffer action passthrough is built (no dead buttons shipped).
+ * beneath, a dependency/mid-action hint, and — when the condition is
+ * available (self + pending + dependencies fulfilled) — the FULFILL button.
+ * The tap IS the commit: APXM drives the CONT buffer off-screen and clicks
+ * APEX's own fulfill control (action-authorisation rule).
  */
-function ConditionBlock({ cond }: { cond: ContractConditionDetail }) {
+function ConditionBlock({ cond, onFulfill, actionRunning }: ConditionBlockProps) {
   const glyph = cond.breached ? '!' : cond.fulfilled ? '✓' : cond.available ? '●' : '✗';
   const glyphColor = cond.breached
     ? 'text-status-critical'
@@ -82,23 +92,48 @@ function ConditionBlock({ cond }: { cond: ContractConditionDetail }) {
           <div className="mt-1 ml-11 text-xs text-apxm-muted">{midActionLabels[cond.status]}</div>
         ) : null}
       </div>
+
+      {cond.available && (
+        <button
+          onClick={onFulfill}
+          disabled={actionRunning}
+          className={`shrink-0 min-h-touch px-3 ${btnSecondary} disabled:opacity-50 disabled:cursor-not-allowed`}
+        >
+          Fulfill
+        </button>
+      )}
     </div>
   );
 }
 
 /**
- * Read-only contract drill-down for the slide-up sheet: partner, timing,
- * acceptance status, and the full condition list with dependency-aware states.
- * Game actions (FULFILL / ACCEPT / REJECT) are not rendered until the
- * CONT-buffer action passthrough is built — the view ships read-only.
+ * Contract drill-down for the slide-up sheet: partner, timing, acceptance,
+ * and the full condition list with dependency-aware states. Game actions
+ * (ACCEPT / REJECT / per-condition FULFILL) run as one-tap passthroughs —
+ * APXM drives the CONT buffer off-screen and clicks APEX's own control; the
+ * user's tap is the commit (#73). Success needs no manual refresh: the
+ * CONTRACTS_CONTRACT delta updates the store and this view re-renders.
  */
 export function ContractDetailView({ contractId }: ContractDetailViewProps) {
   const contract = useContractDetail(contractId);
+  const [actionRunning, setActionRunning] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   // The contract vanished (store cleared on reconnect). The sheet keeps its
   // title from the payload; just say the live detail is gone.
   if (!contract) {
     return <p className="text-sm text-apxm-muted">Contract data unavailable.</p>;
+  }
+
+  async function handleAction(target: ContractActionTarget): Promise<void> {
+    if (actionRunning || !contract) return;
+    setActionRunning(true);
+    setActionError(null);
+    const result = await runContractAction(contract.localId, target);
+    setActionRunning(false);
+    if (!result.ok) {
+      setActionError(result.error);
+    }
   }
 
   return (
@@ -115,21 +150,63 @@ export function ContractDetailView({ contractId }: ContractDetailViewProps) {
         <span>Due {formatDeadline(contract.dueDateMs)}</span>
       </div>
 
-      {/* Acceptance status (informational). ACCEPT/REJECT are contract-level
-          game commands — not shown until the CONT-buffer action passthrough
-          exists, so no dead buttons ship. */}
+      {/* Acceptance: contract-level ACCEPT/REJECT run as one-tap passthroughs. */}
       {contract.acceptance === 'awaiting-mine' && (
-        <p className="text-xs text-status-warning">Awaiting your acceptance.</p>
+        <div className="space-y-2">
+          <p className="text-xs text-status-warning">Awaiting your acceptance.</p>
+          <div className="flex gap-2">
+            <button
+              onClick={() => handleAction({ kind: 'accept' })}
+              disabled={actionRunning}
+              className={`flex-1 min-h-touch px-4 py-2 ${btnPrimary} disabled:opacity-50 disabled:cursor-not-allowed`}
+            >
+              Accept
+            </button>
+            <button
+              onClick={() => handleAction({ kind: 'reject' })}
+              disabled={actionRunning}
+              className={`flex-1 min-h-touch px-4 py-2 ${btnSecondary} disabled:opacity-50 disabled:cursor-not-allowed`}
+            >
+              Reject
+            </button>
+          </div>
+        </div>
       )}
       {contract.acceptance === 'awaiting-partner' && (
         <p className="text-xs text-apxm-muted">Awaiting partner acceptance.</p>
       )}
 
-      {/* Conditions */}
+      {/* In-flight / error line for whichever action ran last */}
+      {actionRunning && (
+        <p className="text-xs text-apxm-muted animate-pulse">Working in APEX buffer...</p>
+      )}
+      {actionError && (
+        <p className="text-xs text-status-critical">
+          <span aria-hidden>! </span>
+          {actionError}
+        </p>
+      )}
+
+      {/* Conditions. Fulfill targets are addressed by their ordinal among
+          AVAILABLE conditions — APEX renders one button per fulfillable row,
+          so the raw condition index would misalign whenever earlier
+          conditions are already fulfilled or belong to the partner. */}
       <div>
         <p className="text-[10px] uppercase tracking-wide text-apxm-text/40 mb-1">Conditions</p>
         {contract.conditions.map((cond) => (
-          <ConditionBlock key={cond.id} cond={cond} />
+          <ConditionBlock
+            key={cond.id}
+            cond={cond}
+            onFulfill={() =>
+              handleAction({
+                kind: 'fulfill',
+                conditionIndex: contract.conditions
+                  .filter((c) => c.available)
+                  .findIndex((c) => c.id === cond.id),
+              })
+            }
+            actionRunning={actionRunning}
+          />
         ))}
       </div>
     </div>

--- a/components/contracts/ContractDetailView.tsx
+++ b/components/contracts/ContractDetailView.tsx
@@ -38,6 +38,9 @@ interface ConditionBlockProps {
   /** Fires the one-tap FULFILL passthrough for this condition (#73). */
   onFulfill: () => void;
   actionRunning: boolean;
+  /** APEX has this condition's button disabled (game-side gate, e.g. shipment
+   *  not yet arrived) — mirror it. Session-scoped; reopening the sheet retries. */
+  gameDisabled: boolean;
 }
 
 /**
@@ -47,7 +50,7 @@ interface ConditionBlockProps {
  * The tap IS the commit: APXM drives the CONT buffer off-screen and clicks
  * APEX's own fulfill control (action-authorisation rule).
  */
-function ConditionBlock({ cond, onFulfill, actionRunning }: ConditionBlockProps) {
+function ConditionBlock({ cond, onFulfill, actionRunning, gameDisabled }: ConditionBlockProps) {
   const glyph = cond.breached ? '!' : cond.fulfilled ? '✓' : cond.available ? '●' : '✗';
   const glyphColor = cond.breached
     ? 'text-status-critical'
@@ -96,7 +99,7 @@ function ConditionBlock({ cond, onFulfill, actionRunning }: ConditionBlockProps)
       {cond.available && (
         <button
           onClick={onFulfill}
-          disabled={actionRunning}
+          disabled={actionRunning || gameDisabled}
           className={`shrink-0 min-h-touch px-3 ${btnSecondary} disabled:opacity-50 disabled:cursor-not-allowed`}
         >
           Fulfill
@@ -118,6 +121,11 @@ export function ContractDetailView({ contractId }: ContractDetailViewProps) {
   const contract = useContractDetail(contractId);
   const [actionRunning, setActionRunning] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
+  // Buttons APEX reported disabled at act time, keyed by condition id (or the
+  // action kind for accept/reject). Session-scoped by design: the gate lifts
+  // on game events the WS contract data doesn't carry (a shipment arriving),
+  // so reopening the sheet is the retry.
+  const [gameDisabled, setGameDisabled] = useState<ReadonlySet<string>>(new Set());
 
   // The contract vanished (store cleared on reconnect). The sheet keeps its
   // title from the payload; just say the live detail is gone.
@@ -125,14 +133,19 @@ export function ContractDetailView({ contractId }: ContractDetailViewProps) {
     return <p className="text-sm text-apxm-muted">Contract data unavailable.</p>;
   }
 
-  async function handleAction(target: ContractActionTarget): Promise<void> {
+  async function handleAction(target: ContractActionTarget, disableKey: string): Promise<void> {
     if (actionRunning || !contract) return;
     setActionRunning(true);
     setActionError(null);
     const result = await runContractAction(contract.localId, target);
     setActionRunning(false);
     if (!result.ok) {
-      setActionError(result.error);
+      if (result.disabledInApex) {
+        // Mirror APEX's disabled button instead of surfacing a message.
+        setGameDisabled((prev) => new Set(prev).add(disableKey));
+      } else {
+        setActionError(result.error);
+      }
     }
   }
 
@@ -156,15 +169,15 @@ export function ContractDetailView({ contractId }: ContractDetailViewProps) {
           <p className="text-xs text-status-warning">Awaiting your acceptance.</p>
           <div className="flex gap-2">
             <button
-              onClick={() => handleAction({ kind: 'accept' })}
-              disabled={actionRunning}
+              onClick={() => handleAction({ kind: 'accept' }, 'accept')}
+              disabled={actionRunning || gameDisabled.has('accept')}
               className={`flex-1 min-h-touch px-4 py-2 ${btnPrimary} disabled:opacity-50 disabled:cursor-not-allowed`}
             >
               Accept
             </button>
             <button
-              onClick={() => handleAction({ kind: 'reject' })}
-              disabled={actionRunning}
+              onClick={() => handleAction({ kind: 'reject' }, 'reject')}
+              disabled={actionRunning || gameDisabled.has('reject')}
               className={`flex-1 min-h-touch px-4 py-2 ${btnSecondary} disabled:opacity-50 disabled:cursor-not-allowed`}
             >
               Reject
@@ -198,9 +211,10 @@ export function ContractDetailView({ contractId }: ContractDetailViewProps) {
             key={cond.id}
             cond={cond}
             onFulfill={() =>
-              handleAction({ kind: 'fulfill', conditionNumber: cond.index + 1 })
+              handleAction({ kind: 'fulfill', conditionNumber: cond.index + 1 }, cond.id)
             }
             actionRunning={actionRunning}
+            gameDisabled={gameDisabled.has(cond.id)}
           />
         ))}
       </div>

--- a/components/contracts/ContractDetailView.tsx
+++ b/components/contracts/ContractDetailView.tsx
@@ -74,6 +74,11 @@ function ConditionBlock({ cond, onFulfill, actionRunning, gameDisabled }: Condit
           >
             {cond.party === 'self' ? 'Self' : cond.partnerName}
           </span>
+          {/* A gated tap proved APEX has this PENDING condition disabled —
+              say so in the game's own status word, next to the party. */}
+          {gameDisabled && cond.status === 'PENDING' && (
+            <span className="shrink-0 text-apxm-muted">pending</span>
+          )}
           {!cond.fulfilled && cond.deadline && (
             <span className="shrink-0 text-apxm-muted font-mono ml-auto">{cond.deadline}</span>
           )}

--- a/components/contracts/ContractDetailView.tsx
+++ b/components/contracts/ContractDetailView.tsx
@@ -224,24 +224,13 @@ export function ContractDetailView({ contractId }: ContractDetailViewProps) {
         ))}
       </div>
 
-      {/* Termination. canRequestTermination is server-authoritative — the
-          same one-tap passthrough as the other actions (the CONT buffer's
-          "request termination" command). */}
+      {/* Termination action lives in the sheet header (ContractTerminateButton);
+          only the state lines render here. */}
       {contract.terminationReceived && (
         <p className="text-xs text-status-warning">Partner requested termination.</p>
       )}
-      {contract.terminationSent ? (
+      {contract.terminationSent && (
         <p className="text-xs text-apxm-muted">Termination requested.</p>
-      ) : (
-        contract.canRequestTermination && (
-          <button
-            onClick={() => handleAction({ kind: 'terminate' }, 'terminate')}
-            disabled={actionRunning || gameDisabled.has('terminate')}
-            className={`w-full min-h-touch px-4 py-2 ${btnSecondary} disabled:opacity-50 disabled:cursor-not-allowed`}
-          >
-            Request Termination
-          </button>
-        )
       )}
     </div>
   );

--- a/components/contracts/ContractDetailView.tsx
+++ b/components/contracts/ContractDetailView.tsx
@@ -187,10 +187,10 @@ export function ContractDetailView({ contractId }: ContractDetailViewProps) {
         </p>
       )}
 
-      {/* Conditions. Fulfill targets are addressed by their ordinal among
-          AVAILABLE conditions — APEX renders one button per fulfillable row,
-          so the raw condition index would misalign whenever earlier
-          conditions are already fulfilled or belong to the partner. */}
+      {/* Conditions. Fulfill targets are addressed by the game-displayed
+          condition number — the CONT buffer's rows carry it, and APEX renders
+          (disabled) buttons even on rows APXM doesn't consider available, so
+          ordinal counting would misalign. */}
       <div>
         <p className="text-[10px] uppercase tracking-wide text-apxm-text/40 mb-1">Conditions</p>
         {contract.conditions.map((cond) => (
@@ -198,12 +198,7 @@ export function ContractDetailView({ contractId }: ContractDetailViewProps) {
             key={cond.id}
             cond={cond}
             onFulfill={() =>
-              handleAction({
-                kind: 'fulfill',
-                conditionIndex: contract.conditions
-                  .filter((c) => c.available)
-                  .findIndex((c) => c.id === cond.id),
-              })
+              handleAction({ kind: 'fulfill', conditionNumber: cond.index + 1 })
             }
             actionRunning={actionRunning}
           />

--- a/components/contracts/ContractDetailView.tsx
+++ b/components/contracts/ContractDetailView.tsx
@@ -223,6 +223,26 @@ export function ContractDetailView({ contractId }: ContractDetailViewProps) {
           />
         ))}
       </div>
+
+      {/* Termination. canRequestTermination is server-authoritative — the
+          same one-tap passthrough as the other actions (the CONT buffer's
+          "request termination" command). */}
+      {contract.terminationReceived && (
+        <p className="text-xs text-status-warning">Partner requested termination.</p>
+      )}
+      {contract.terminationSent ? (
+        <p className="text-xs text-apxm-muted">Termination requested.</p>
+      ) : (
+        contract.canRequestTermination && (
+          <button
+            onClick={() => handleAction({ kind: 'terminate' }, 'terminate')}
+            disabled={actionRunning || gameDisabled.has('terminate')}
+            className={`w-full min-h-touch px-4 py-2 ${btnSecondary} disabled:opacity-50 disabled:cursor-not-allowed`}
+          >
+            Request Termination
+          </button>
+        )
+      )}
     </div>
   );
 }

--- a/components/contracts/ContractTerminateButton.tsx
+++ b/components/contracts/ContractTerminateButton.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import { btnSecondary } from '../shared';
+import { useContractDetail } from '../views/hooks';
+import { runContractAction } from '../../lib/contract-actions';
+
+/**
+ * Compact "request termination" passthrough for the contract sheet HEADER —
+ * deliberately out of the main flow (device ruling: a full-width button at
+ * the bottom was too prominent and mis-tappable). Self-contained state; the
+ * module-level in-flight guard in contract-actions serialises it against the
+ * body's ACCEPT/REJECT/FULFILL buttons. Hidden once termination is sent or
+ * when the server doesn't offer it; the body renders the sent/received
+ * status lines.
+ */
+export function ContractTerminateButton({ contractId }: { contractId: string }) {
+  const contract = useContractDetail(contractId);
+  const [running, setRunning] = useState(false);
+  const [gameDisabled, setGameDisabled] = useState(false);
+
+  if (!contract || !contract.canRequestTermination || contract.terminationSent) return null;
+
+  async function handleTap(): Promise<void> {
+    if (running || !contract) return;
+    setRunning(true);
+    const result = await runContractAction(contract.localId, { kind: 'terminate' });
+    setRunning(false);
+    if (!result.ok && result.disabledInApex) setGameDisabled(true);
+  }
+
+  return (
+    <button
+      onClick={handleTap}
+      disabled={running || gameDisabled}
+      className={`shrink-0 min-h-touch px-2 text-[10px] ${btnSecondary} disabled:opacity-50 disabled:cursor-not-allowed`}
+    >
+      Request Termination
+    </button>
+  );
+}

--- a/components/contracts/index.ts
+++ b/components/contracts/index.ts
@@ -1,2 +1,3 @@
 export { ContractRow } from './ContractRow';
 export { ContractDetailView } from './ContractDetailView';
+export { ContractTerminateButton } from './ContractTerminateButton';

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -2,6 +2,7 @@ import { useGameState } from '../../stores/gameState';
 import { Header } from './Header';
 import { TabBar } from './TabBar';
 import { FloatingReturn } from './FloatingReturn';
+import { ConfirmBar } from './ConfirmBar';
 import { DetailSheet } from './DetailSheet';
 import { StatusView } from '../views/StatusView';
 import { FleetView } from '../views/FleetView';
@@ -28,20 +29,32 @@ function ViewContent() {
 
 export function AppShell() {
   const apexVisible = useGameState((s) => s.apexVisible);
+  const actConfirmPending = useGameState((s) => s.actConfirmPending);
 
   if (apexVisible) {
     return <FloatingReturn />;
   }
 
+  // During a manual-confirm window the shell hides via CSS (it must stay
+  // MOUNTED — unmounting would drop the in-flight action's React owner) and
+  // the ConfirmBar is the only chrome; the host background drops via
+  // :host(.act-confirm) so APEX's dialog underneath is visible and tappable.
   return (
-    <div className="relative w-full h-dvh flex flex-col bg-apxm-bg text-apxm-text overflow-hidden pointer-events-auto">
-      <Header />
-      <main className="flex-1 overflow-y-auto overflow-x-hidden p-4 min-w-0">
-        <ViewContent />
-      </main>
-      <TabBar />
-      {/* Drill-down sheet — overlays the whole shell when a detailView is set */}
-      <DetailSheet />
-    </div>
+    <>
+      {actConfirmPending && <ConfirmBar />}
+      <div
+        className={`relative w-full h-dvh flex-col bg-apxm-bg text-apxm-text overflow-hidden pointer-events-auto ${
+          actConfirmPending ? 'hidden' : 'flex'
+        }`}
+      >
+        <Header />
+        <main className="flex-1 overflow-y-auto overflow-x-hidden p-4 min-w-0">
+          <ViewContent />
+        </main>
+        <TabBar />
+        {/* Drill-down sheet — overlays the whole shell when a detailView is set */}
+        <DetailSheet />
+      </div>
+    </>
   );
 }

--- a/components/layout/ConfirmBar.tsx
+++ b/components/layout/ConfirmBar.tsx
@@ -1,0 +1,20 @@
+/**
+ * The only APXM chrome shown during a manual-confirm window: a driven APEX
+ * action hit the game's confirmation dialog and settings.autoConfirm is off,
+ * so the user must tap CONFIRM (or cancel) in APEX itself — the commit stays
+ * theirs. AppShell hides the opaque shell and drops the host background while
+ * this bar is up (see :host(.act-confirm) in styles.css).
+ *
+ * Top placement keeps clear of the dialog, which APEX renders over the buffer
+ * body — but that is device-validated, not guaranteed (#73 checklist).
+ */
+export function ConfirmBar() {
+  return (
+    <div className="fixed top-0 left-0 right-0 z-[999999] h-11 min-h-touch px-4 bg-apxm-bg text-apxm-text font-mono text-[11px] font-semibold tracking-wider uppercase flex items-center justify-between border-b border-prun-yellow pointer-events-auto">
+      <span>
+        <span className="text-prun-yellow">▼</span>
+        <span className="ml-2">Confirm or cancel in APEX below</span>
+      </span>
+    </div>
+  );
+}

--- a/components/layout/DetailSheet.tsx
+++ b/components/layout/DetailSheet.tsx
@@ -3,7 +3,7 @@ import { useGameState, type DetailView } from '../../stores/gameState';
 import { ProductionView } from '../production';
 import { BurnDetailView, RepairDetailView } from '../burn';
 import { ShipDetailView } from '../fleet';
-import { ContractDetailView } from '../contracts';
+import { ContractDetailView, ContractTerminateButton } from '../contracts';
 
 const detailLabels: Record<DetailView['type'], string> = {
   production: 'Production',
@@ -84,6 +84,9 @@ export function DetailSheet() {
             </p>
             <h2 className="font-semibold text-apxm-text truncate">{detailTitle(detailView)}</h2>
           </div>
+          {detailView.type === 'contract' && (
+            <ContractTerminateButton contractId={detailView.contractId} />
+          )}
           <button
             onClick={close}
             aria-label="Close production view"

--- a/components/views/hooks/__tests__/useContractDetails.test.ts
+++ b/components/views/hooks/__tests__/useContractDetails.test.ts
@@ -141,6 +141,19 @@ describe('buildContractDetail — dependency-aware condition flags', () => {
     expect(buildContractDetail(noneAvailable).actionable).toBe(false);
   });
 
+  it('maps the termination fields straight from the wire contract', () => {
+    const detail = buildContractDetail(
+      createTestContract({
+        canRequestTermination: true,
+        terminationSent: true,
+        terminationReceived: false,
+      })
+    );
+    expect(detail.canRequestTermination).toBe(true);
+    expect(detail.terminationSent).toBe(true);
+    expect(detail.terminationReceived).toBe(false);
+  });
+
   it('keeps breached as a convenience for the VIOLATED condition status', () => {
     const contract = acceptedContract([
       selfCondition({ id: 'c1', index: 0, status: 'VIOLATED', dependencies: [] }),

--- a/components/views/hooks/useContractDetails.ts
+++ b/components/views/hooks/useContractDetails.ts
@@ -77,6 +77,12 @@ export interface ContractDetail {
   accepted: boolean;
   /** Faction/agent contract (partner carries a countryCode). */
   isFaction: boolean;
+  /** Server-authoritative: the CONT buffer offers "request termination". */
+  canRequestTermination: boolean;
+  /** You already requested termination — the button is spent. */
+  terminationSent: boolean;
+  /** The partner requested termination. */
+  terminationReceived: boolean;
 }
 
 /**
@@ -307,6 +313,9 @@ export function buildContractDetail(contract: PrunApi.Contract): ContractDetail 
     acceptance: deriveAcceptance(contract),
     accepted: isContractAccepted(contract),
     isFaction: isFactionContract(contract),
+    canRequestTermination: contract.canRequestTermination,
+    terminationSent: contract.terminationSent,
+    terminationReceived: contract.terminationReceived,
   };
 }
 

--- a/lib/__tests__/contract-actions.test.ts
+++ b/lib/__tests__/contract-actions.test.ts
@@ -1,0 +1,181 @@
+// One-tap contract passthrough (#73): drive the CONT buffer off-screen,
+// click APEX's own button, observe the feedback overlay. The navigator is
+// device-validated separately — stubbed here; the fixtures model APEX's
+// overlay state machine like step-machine-gate.test.ts does.
+
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+
+vi.mock('../mobile-buffer-navigator', () => ({
+  openMobileBuffer: vi.fn(async () => true),
+  closeMobileBuffer: vi.fn(async () => {}),
+}));
+
+import { openMobileBuffer, closeMobileBuffer } from '../mobile-buffer-navigator';
+import {
+  runContractAction,
+  findContractActionButton,
+  type ContractActionTarget,
+} from '../contract-actions';
+import { setupActGlobals } from '../act/globals-setup';
+import { C } from '../act/prun-css';
+import { useSettingsStore } from '../../stores/settings';
+import { useGameState } from '../../stores/gameState';
+
+beforeAll(() => {
+  setupActGlobals();
+  Object.assign(C, {
+    ActionFeedback: {
+      overlay: 'af-overlay',
+      progress: 'af-progress',
+      success: 'af-success',
+      error: 'af-error',
+      message: 'af-message',
+      dismiss: 'af-dismiss',
+    },
+    ActionConfirmationOverlay: { container: 'aco-container' },
+    Button: { btn: 'apex-btn' },
+  });
+});
+
+function makeButton(label: string): HTMLButtonElement {
+  const btn = document.createElement('button');
+  btn.textContent = label;
+  return btn;
+}
+
+/** A minimal CONT buffer inside #container: action buttons + an overlay. */
+function buildContainer(buttons: string[], overlayClass: string): {
+  container: HTMLElement;
+  overlay: HTMLElement;
+  clicks: string[];
+} {
+  const container = document.createElement('div');
+  container.id = 'container';
+  document.body.appendChild(container);
+  const clicks: string[] = [];
+  for (const label of buttons) {
+    const btn = makeButton(label);
+    btn.addEventListener('click', () => clicks.push(label));
+    container.appendChild(btn);
+  }
+  const overlay = document.createElement('div');
+  overlay.className = overlayClass;
+  container.appendChild(overlay);
+  return { container, overlay, clicks };
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+  vi.mocked(openMobileBuffer).mockClear();
+  vi.mocked(closeMobileBuffer).mockClear();
+  useSettingsStore.getState().setAutoConfirm(false);
+  useGameState.getState().setActConfirmPending(false);
+});
+
+describe('findContractActionButton', () => {
+  it('matches labels case-insensitively (APEX uppercases via CSS)', () => {
+    const { container } = buildContainer(['ACCEPT', 'Reject'], 'af-overlay');
+    expect(findContractActionButton(container, { kind: 'accept' })?.textContent).toBe('ACCEPT');
+    expect(findContractActionButton(container, { kind: 'reject' })?.textContent).toBe('Reject');
+  });
+
+  it('picks the Nth fulfill button by available-ordinal', () => {
+    const { container } = buildContainer(['Fulfill', 'Fulfill'], 'af-overlay');
+    const target: ContractActionTarget = { kind: 'fulfill', conditionIndex: 1 };
+    const buttons = container.getElementsByTagName('button');
+    expect(findContractActionButton(container, target)).toBe(buttons[1]);
+  });
+
+  it('a single fulfill match is used regardless of ordinal', () => {
+    const { container } = buildContainer(['Pay'], 'af-overlay');
+    expect(
+      findContractActionButton(container, { kind: 'fulfill', conditionIndex: 3 })?.textContent
+    ).toBe('Pay');
+  });
+
+  it('returns undefined when nothing matches', () => {
+    const { container } = buildContainer(['Cancel'], 'af-overlay');
+    expect(findContractActionButton(container, { kind: 'accept' })).toBeUndefined();
+  });
+});
+
+describe('runContractAction', () => {
+  it('opens the CONT buffer, clicks the button, and reports success', async () => {
+    const { clicks } = buildContainer(['Accept', 'Reject'], 'af-overlay af-success');
+
+    const result = await runContractAction('ABC123', { kind: 'accept' });
+
+    expect(openMobileBuffer).toHaveBeenCalledWith('CONT ABC123');
+    expect(clicks).toEqual(['Accept']);
+    expect(result).toEqual({ ok: true });
+    expect(closeMobileBuffer).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports APEX error text and still restores the buffer', async () => {
+    const { overlay } = buildContainer(['Accept'], 'af-overlay af-error');
+    const message = document.createElement('span');
+    message.className = 'af-message';
+    message.textContent = 'Insufficient funds';
+    overlay.appendChild(message);
+
+    const result = await runContractAction('ABC123', { kind: 'accept' });
+
+    expect(result).toEqual({ ok: false, error: 'Insufficient funds' });
+    expect(closeMobileBuffer).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails cleanly (buffer restored) when the button is missing', async () => {
+    buildContainer(['Cancel'], 'af-overlay af-success');
+
+    const result = await runContractAction('ABC123', { kind: 'reject' });
+
+    expect(result.ok).toBe(false);
+    expect(closeMobileBuffer).toHaveBeenCalledTimes(1);
+  });
+
+  it('drives actConfirmPending true→false around the manual-confirm window', async () => {
+    const { overlay } = buildContainer(['Accept'], 'af-overlay aco-container');
+    const pendingSeen: boolean[] = [];
+    const unsubscribe = useGameState.subscribe((s) => {
+      pendingSeen.push(s.actConfirmPending);
+    });
+    // User taps CONFIRM in APEX a beat later.
+    setTimeout(() => {
+      overlay.classList.remove('aco-container');
+      overlay.classList.add('af-success');
+    }, 20);
+
+    const result = await runContractAction('ABC123', { kind: 'accept' });
+    unsubscribe();
+
+    expect(result).toEqual({ ok: true });
+    expect(pendingSeen).toContain(true);
+    expect(useGameState.getState().actConfirmPending).toBe(false);
+  });
+
+  it('rejects a second tap while an action is in flight', async () => {
+    const { overlay } = buildContainer(['Accept'], 'af-overlay aco-container');
+    setTimeout(() => {
+      overlay.classList.remove('aco-container');
+      overlay.classList.add('af-success');
+    }, 30);
+
+    const first = runContractAction('ABC123', { kind: 'accept' });
+    const second = await runContractAction('ABC123', { kind: 'accept' });
+
+    expect(second).toEqual({ ok: false, error: 'Another action is already running' });
+    expect(await first).toEqual({ ok: true });
+    // Only the first action opened a buffer.
+    expect(openMobileBuffer).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails without clicking anything when the buffer cannot be opened', async () => {
+    buildContainer(['Accept'], 'af-overlay af-success');
+    vi.mocked(openMobileBuffer).mockResolvedValueOnce(false);
+
+    const result = await runContractAction('ABC123', { kind: 'accept' });
+
+    expect(result.ok).toBe(false);
+    expect(closeMobileBuffer).not.toHaveBeenCalled();
+  });
+});

--- a/lib/__tests__/contract-actions.test.ts
+++ b/lib/__tests__/contract-actions.test.ts
@@ -14,6 +14,7 @@ import { openMobileBuffer, closeMobileBuffer } from '../mobile-buffer-navigator'
 import {
   runContractAction,
   findContractActionButton,
+  isApexButtonDisabled,
   type ContractActionTarget,
 } from '../contract-actions';
 import { setupActGlobals } from '../act/globals-setup';
@@ -33,7 +34,7 @@ beforeAll(() => {
       dismiss: 'af-dismiss',
     },
     ActionConfirmationOverlay: { container: 'aco-container' },
-    Button: { btn: 'apex-btn' },
+    Button: { btn: 'apex-btn', disabled: 'apex-btn-disabled' },
   });
 });
 
@@ -138,6 +139,34 @@ describe('findContractActionButton', () => {
   });
 });
 
+describe('isApexButtonDisabled', () => {
+  // Device capture 2026-08-13: APEX gates buttons with a Button__disabled
+  // class, NOT the disabled attribute — clicking one is a silent no-op.
+  it('detects the parsed C.Button.disabled class', () => {
+    const btn = makeButton('fulfill');
+    btn.className = 'apex-btn-disabled apex-btn';
+    expect(isApexButtonDisabled(btn)).toBe(true);
+  });
+
+  it('detects the raw BEM prefix when stylesheet parsing is unavailable', () => {
+    const btn = makeButton('fulfill');
+    btn.className = 'Button__disabled___x8i7XF Button__btn___UJGZ1b7';
+    expect(isApexButtonDisabled(btn)).toBe(true);
+  });
+
+  it('detects the standard disabled attribute', () => {
+    const btn = makeButton('fulfill');
+    btn.disabled = true;
+    expect(isApexButtonDisabled(btn)).toBe(true);
+  });
+
+  it('an enabled button is not disabled', () => {
+    const btn = makeButton('fulfill');
+    btn.className = 'apex-btn';
+    expect(isApexButtonDisabled(btn)).toBe(false);
+  });
+});
+
 describe('runContractAction', () => {
   it('opens the CONT buffer, clicks the button, and reports success', async () => {
     const { clicks } = buildContainer(['Accept', 'Reject'], 'af-overlay af-success');
@@ -160,6 +189,23 @@ describe('runContractAction', () => {
     const result = await runContractAction('ABC123', { kind: 'accept' });
 
     expect(result).toEqual({ ok: false, error: 'Insufficient funds' });
+    expect(closeMobileBuffer).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports disabledInApex without clicking when APEX gates the button', async () => {
+    const { container, clicks } = buildContainer([], 'af-overlay af-success');
+    buildConditionsTable(container, [
+      { n: 3, label: 'fulfill', disabledClass: 'Button__disabled___x8i7XF Button__btn___UJGZ1b7' },
+    ]);
+
+    const result = await runContractAction('ABC123', { kind: 'fulfill', conditionNumber: 3 });
+
+    expect(result).toEqual({
+      ok: false,
+      disabledInApex: true,
+      error: 'Not yet enabled in APEX',
+    });
+    expect(clicks).toEqual([]);
     expect(closeMobileBuffer).toHaveBeenCalledTimes(1);
   });
 

--- a/lib/__tests__/contract-actions.test.ts
+++ b/lib/__tests__/contract-actions.test.ts
@@ -137,6 +137,13 @@ describe('findContractActionButton', () => {
     const { container } = buildContainer(['Cancel'], 'af-overlay');
     expect(findContractActionButton(container, { kind: 'accept' })).toBeUndefined();
   });
+
+  it('matches the request-termination command (device-captured label)', () => {
+    const { container } = buildContainer(['request termination'], 'af-overlay');
+    expect(findContractActionButton(container, { kind: 'terminate' })?.textContent).toBe(
+      'request termination'
+    );
+  });
 });
 
 describe('isApexButtonDisabled', () => {

--- a/lib/__tests__/contract-actions.test.ts
+++ b/lib/__tests__/contract-actions.test.ts
@@ -72,6 +72,31 @@ beforeEach(() => {
   useGameState.getState().setActConfirmPending(false);
 });
 
+/** The CONT conditions table, as device-captured 2026-08-13: one row per
+ *  condition, index cell first ("#3"), the (possibly disabled) action button
+ *  in the last cell. */
+function buildConditionsTable(
+  host: HTMLElement,
+  rows: { n: number; label?: string; disabledClass?: string }[]
+): void {
+  const table = document.createElement('table');
+  for (const row of rows) {
+    const tr = document.createElement('tr');
+    const indexCell = document.createElement('td');
+    indexCell.textContent = `#${row.n}`;
+    tr.appendChild(indexCell);
+    const cmdCell = document.createElement('td');
+    if (row.label) {
+      const btn = makeButton(row.label);
+      if (row.disabledClass) btn.className = row.disabledClass;
+      cmdCell.appendChild(btn);
+    }
+    tr.appendChild(cmdCell);
+    table.appendChild(tr);
+  }
+  host.appendChild(table);
+}
+
 describe('findContractActionButton', () => {
   it('matches labels case-insensitively (APEX uppercases via CSS)', () => {
     const { container } = buildContainer(['ACCEPT', 'Reject'], 'af-overlay');
@@ -79,18 +104,32 @@ describe('findContractActionButton', () => {
     expect(findContractActionButton(container, { kind: 'reject' })?.textContent).toBe('Reject');
   });
 
-  it('picks the Nth fulfill button by available-ordinal', () => {
-    const { container } = buildContainer(['Fulfill', 'Fulfill'], 'af-overlay');
-    const target: ContractActionTarget = { kind: 'fulfill', conditionIndex: 1 };
-    const buttons = container.getElementsByTagName('button');
-    expect(findContractActionButton(container, target)).toBe(buttons[1]);
+  it('fulfill picks the button from the row whose index cell matches', () => {
+    const { container } = buildContainer([], 'af-overlay');
+    // Device-observed shape: APEX renders buttons on BOTH self rows (#3 deps
+    // met but game-gated, #5 deps unmet) — row addressing must not count.
+    buildConditionsTable(container, [
+      { n: 3, label: 'fulfill' },
+      { n: 4 },
+      { n: 5, label: 'fulfill' },
+    ]);
+    const target: ContractActionTarget = { kind: 'fulfill', conditionNumber: 5 };
+    const found = findContractActionButton(container, target);
+    expect(found).toBe(container.getElementsByTagName('button')[1]);
   });
 
-  it('a single fulfill match is used regardless of ordinal', () => {
+  it('falls back to a single unambiguous label match when no row matches', () => {
     const { container } = buildContainer(['Pay'], 'af-overlay');
     expect(
-      findContractActionButton(container, { kind: 'fulfill', conditionIndex: 3 })?.textContent
+      findContractActionButton(container, { kind: 'fulfill', conditionNumber: 3 })?.textContent
     ).toBe('Pay');
+  });
+
+  it('refuses to guess among multiple matches when no row matches', () => {
+    const { container } = buildContainer(['Fulfill', 'Fulfill'], 'af-overlay');
+    expect(
+      findContractActionButton(container, { kind: 'fulfill', conditionNumber: 2 })
+    ).toBeUndefined();
   });
 
   it('returns undefined when nothing matches', () => {

--- a/lib/act/__tests__/action-feedback.test.ts
+++ b/lib/act/__tests__/action-feedback.test.ts
@@ -1,0 +1,123 @@
+// The onManualConfirm visibility signal: fired around the manual-confirm
+// window (true before the wait, false when it resolves) so the caller can
+// make APEX visible for the user's CONFIRM tap — the APXM shadow host is an
+// opaque cover, so without this signal the dialog is un-hidden underneath it.
+
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+import { waitActionFeedback } from '../action-feedback';
+import { setupActGlobals } from '../globals-setup';
+import { C } from '../prun-css';
+
+beforeAll(() => {
+  setupActGlobals();
+  Object.assign(C, {
+    ActionFeedback: {
+      overlay: 'af-overlay',
+      progress: 'af-progress',
+      success: 'af-success',
+      error: 'af-error',
+      message: 'af-message',
+      dismiss: 'af-dismiss',
+    },
+    ActionConfirmationOverlay: { container: 'aco-container' },
+    Button: { btn: 'apex-btn' },
+  });
+});
+
+interface Fixture {
+  anchor: HTMLElement;
+  overlay: HTMLElement;
+  resolveConfirmation: () => void;
+}
+
+function buildConfirmationOverlay(): Fixture {
+  const anchor = document.createElement('div');
+  anchor.style.visibility = 'hidden';
+  anchor.style.left = '-9999px';
+  document.body.appendChild(anchor);
+
+  const overlay = document.createElement('div');
+  overlay.className = 'af-overlay aco-container';
+  const cancelBtn = document.createElement('button');
+  cancelBtn.className = 'apex-btn';
+  const confirmBtn = document.createElement('button');
+  confirmBtn.className = 'apex-btn';
+  confirmBtn.addEventListener('click', () => {
+    overlay.classList.remove('aco-container');
+    overlay.classList.add('af-success');
+  });
+  overlay.append(cancelBtn, confirmBtn);
+  anchor.appendChild(overlay);
+  return {
+    anchor,
+    overlay,
+    resolveConfirmation: () => {
+      overlay.classList.remove('aco-container');
+      overlay.classList.add('af-success');
+    },
+  };
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('waitActionFeedback onManualConfirm signal', () => {
+  it('fires true entering the manual window and false after the user resolves it', async () => {
+    const fixture = buildConfirmationOverlay();
+    const events: boolean[] = [];
+    const anchorVisibleAt: string[] = [];
+    const onManualConfirm = vi.fn((pending: boolean) => {
+      events.push(pending);
+      anchorVisibleAt.push(fixture.anchor.style.visibility);
+    });
+    setTimeout(() => fixture.resolveConfirmation(), 20);
+
+    const error = await waitActionFeedback({ anchor: fixture.anchor }, false, onManualConfirm);
+
+    expect(error).toBeUndefined();
+    expect(events).toEqual([true, false]);
+    // true arrives AFTER the engine un-hides the buffer, false BEFORE it
+    // re-hides — the visible window fully covers the wait.
+    expect(anchorVisibleAt).toEqual(['visible', 'visible']);
+  });
+
+  it('never fires under autoConfirm (no manual window exists)', async () => {
+    const fixture = buildConfirmationOverlay();
+    const onManualConfirm = vi.fn();
+
+    const error = await waitActionFeedback({ anchor: fixture.anchor }, true, onManualConfirm);
+
+    expect(error).toBeUndefined();
+    expect(onManualConfirm).not.toHaveBeenCalled();
+  });
+
+  it('delivers false when the overlay is removed (user cancelled in APEX)', async () => {
+    const fixture = buildConfirmationOverlay();
+    const events: boolean[] = [];
+    setTimeout(() => fixture.overlay.remove(), 20);
+
+    const error = await waitActionFeedback({ anchor: fixture.anchor }, false, (p) =>
+      events.push(p)
+    );
+
+    // A cancel falls through the success/error checks — the action failed,
+    // but the visibility signal must still be balanced.
+    expect(error).toBe('Unknown action feedback overlay');
+    expect(events).toEqual([true, false]);
+  });
+
+  it('skips the signal entirely when no confirmation state occurs', async () => {
+    const anchor = document.createElement('div');
+    document.body.appendChild(anchor);
+    const overlay = document.createElement('div');
+    overlay.className = 'af-overlay af-success';
+    anchor.appendChild(overlay);
+    const onManualConfirm = vi.fn();
+
+    const error = await waitActionFeedback({ anchor }, false, onManualConfirm);
+
+    expect(error).toBeUndefined();
+    expect(onManualConfirm).not.toHaveBeenCalled();
+  });
+});

--- a/lib/act/action-feedback.ts
+++ b/lib/act/action-feedback.ts
@@ -1,0 +1,117 @@
+// Extracted from runner/step-machine.ts so a single implementation serves
+// both the ACT step machine and one-shot passthrough actions (contract
+// ACCEPT/REJECT — issue #73). Fire-and-observe: after a button click in an
+// APEX buffer, watch the ActionFeedback overlay through progress /
+// confirmation / success / error.
+
+import { clickElement } from './_compat';
+import type { PrunTile } from './runtime-types';
+
+export async function waitActionFeedback(
+  tile: PrunTile,
+  autoConfirm: boolean,
+  /**
+   * Fired around the manual-confirm window (true right before the wait,
+   * false when it resolves). The APXM shadow host is an opaque fullscreen
+   * cover, so whoever runs the action must use this signal to make APEX
+   * visible for the user's CONFIRM tap — the engine's own un-hide of
+   * #container below is not enough on its own.
+   */
+  onManualConfirm?: (pending: boolean) => void
+): Promise<string | undefined> {
+  const overlay = await $(tile.anchor, C.ActionFeedback.overlay);
+  if (!overlay) {
+    return 'Action feedback overlay did not appear';
+  }
+  await waitActionProgress(overlay);
+  if (overlay.classList.contains(C.ActionConfirmationOverlay.container)) {
+    if (autoConfirm) {
+      const confirm = _$$(overlay, C.Button.btn)[1];
+      if (confirm === undefined) {
+        return 'Confirmation overlay is missing confirm button';
+      }
+      await clickElement(confirm);
+    } else {
+      // Manual confirm (the default): the user must tap APEX's CONFIRM
+      // themselves. The buffer may be parked off-screen (openMobileBuffer
+      // hides #container — CXPO leaves it hidden), so bring it on-screen for
+      // the tap and restore afterwards. MTRA already shows the container, in
+      // which case this save/restore is a no-op.
+      const anchor = tile.anchor;
+      const prev = { visibility: anchor.style.visibility, left: anchor.style.left };
+      anchor.style.visibility = 'visible';
+      anchor.style.left = '0px';
+      onManualConfirm?.(true);
+      try {
+        await waitConfirmationResolved(overlay);
+      } finally {
+        onManualConfirm?.(false);
+        anchor.style.left = prev.left;
+        anchor.style.visibility = prev.visibility;
+      }
+    }
+    await waitActionProgress(overlay);
+  }
+  if (overlay.classList.contains(C.ActionFeedback.success)) {
+    await clickElement(overlay);
+    return;
+  }
+  if (overlay.classList.contains(C.ActionFeedback.error)) {
+    const message = _$(overlay, C.ActionFeedback.message)?.textContent;
+    const dismiss = _$(overlay, C.ActionFeedback.dismiss)?.textContent;
+    return dismiss ? message?.replace(dismiss, '') ?? undefined : message ?? undefined;
+  }
+
+  return 'Unknown action feedback overlay';
+}
+
+// Manual-confirm wait: resolves when the overlay leaves the confirmation
+// state. Two exits: (a) the overlay's own classList changes — after the user
+// taps CONFIRM, APEX transitions the same element through progress to
+// success/error, exactly the transition the auto-click path observes; or
+// (b) the overlay is detached — the user tapped CANCEL or APEX dismissed it
+// (a cancel then falls through the success/error checks and fails the step).
+// No timeout: like waitAct(), a human decision is unbounded.
+function waitConfirmationResolved(overlay: HTMLElement): Promise<void> {
+  if (!overlay.classList.contains(C.ActionConfirmationOverlay.container) || !overlay.isConnected) {
+    return Promise.resolve();
+  }
+  return new Promise<void>(resolve => {
+    const done = () => {
+      attrObserver.disconnect();
+      removalObserver.disconnect();
+      resolve();
+    };
+    const attrObserver = new MutationObserver(() => {
+      if (!overlay.classList.contains(C.ActionConfirmationOverlay.container)) {
+        done();
+      }
+    });
+    attrObserver.observe(overlay, { attributes: true, attributeFilter: ['class'] });
+    // A class observer never fires on node removal — watch the parent tree.
+    const removalObserver = new MutationObserver(() => {
+      if (!overlay.isConnected) {
+        done();
+      }
+    });
+    removalObserver.observe(overlay.parentElement ?? document.body, {
+      childList: true,
+      subtree: true,
+    });
+  });
+}
+
+async function waitActionProgress(overlay: HTMLElement) {
+  if (!overlay.classList.contains(C.ActionFeedback.progress)) {
+    return;
+  }
+  await new Promise<void>(resolve => {
+    const mutationObserver = new MutationObserver(() => {
+      if (!overlay.classList.contains(C.ActionFeedback.progress)) {
+        mutationObserver.disconnect();
+        resolve();
+      }
+    });
+    mutationObserver.observe(overlay, { attributes: true });
+  });
+}

--- a/lib/act/runner/step-machine.ts
+++ b/lib/act/runner/step-machine.ts
@@ -6,8 +6,9 @@
 import { act } from '../act-registry';
 import { ActionStep } from '../shared-types';
 import { Logger } from './logger';
-import { clickElement, sleep } from '../_compat';
+import { sleep } from '../_compat';
 import type { PrunTile } from '../runtime-types';
+import { waitActionFeedback } from '../action-feedback';
 import { openMobileBuffer, closeMobileBuffer } from '../../mobile-buffer-navigator';
 import { clearMtraBufferCache } from '../action-steps/MTRA_TRANSFER';
 import { useSettingsStore } from '../../../stores/settings';
@@ -187,101 +188,3 @@ export class StepMachine {
   }
 }
 
-async function waitActionFeedback(
-  tile: PrunTile,
-  autoConfirm: boolean,
-): Promise<string | undefined> {
-  const overlay = await $(tile.anchor, C.ActionFeedback.overlay);
-  if (!overlay) {
-    return 'Action feedback overlay did not appear';
-  }
-  await waitActionProgress(overlay);
-  if (overlay.classList.contains(C.ActionConfirmationOverlay.container)) {
-    if (autoConfirm) {
-      const confirm = _$$(overlay, C.Button.btn)[1];
-      if (confirm === undefined) {
-        return 'Confirmation overlay is missing confirm button';
-      }
-      await clickElement(confirm);
-    } else {
-      // Manual confirm (the default): the user must tap APEX's CONFIRM
-      // themselves. The buffer may be parked off-screen (openMobileBuffer
-      // hides #container — CXPO leaves it hidden), so bring it on-screen for
-      // the tap and restore afterwards. MTRA already shows the container, in
-      // which case this save/restore is a no-op.
-      const anchor = tile.anchor;
-      const prev = { visibility: anchor.style.visibility, left: anchor.style.left };
-      anchor.style.visibility = 'visible';
-      anchor.style.left = '0px';
-      try {
-        await waitConfirmationResolved(overlay);
-      } finally {
-        anchor.style.left = prev.left;
-        anchor.style.visibility = prev.visibility;
-      }
-    }
-    await waitActionProgress(overlay);
-  }
-  if (overlay.classList.contains(C.ActionFeedback.success)) {
-    await clickElement(overlay);
-    return;
-  }
-  if (overlay.classList.contains(C.ActionFeedback.error)) {
-    const message = _$(overlay, C.ActionFeedback.message)?.textContent;
-    const dismiss = _$(overlay, C.ActionFeedback.dismiss)?.textContent;
-    return dismiss ? message?.replace(dismiss, '') ?? undefined : message ?? undefined;
-  }
-
-  return 'Unknown action feedback overlay';
-}
-
-// Manual-confirm wait: resolves when the overlay leaves the confirmation
-// state. Two exits: (a) the overlay's own classList changes — after the user
-// taps CONFIRM, APEX transitions the same element through progress to
-// success/error, exactly the transition the auto-click path observes; or
-// (b) the overlay is detached — the user tapped CANCEL or APEX dismissed it
-// (a cancel then falls through the success/error checks and fails the step).
-// No timeout: like waitAct(), a human decision is unbounded.
-function waitConfirmationResolved(overlay: HTMLElement): Promise<void> {
-  if (!overlay.classList.contains(C.ActionConfirmationOverlay.container) || !overlay.isConnected) {
-    return Promise.resolve();
-  }
-  return new Promise<void>(resolve => {
-    const done = () => {
-      attrObserver.disconnect();
-      removalObserver.disconnect();
-      resolve();
-    };
-    const attrObserver = new MutationObserver(() => {
-      if (!overlay.classList.contains(C.ActionConfirmationOverlay.container)) {
-        done();
-      }
-    });
-    attrObserver.observe(overlay, { attributes: true, attributeFilter: ['class'] });
-    // A class observer never fires on node removal — watch the parent tree.
-    const removalObserver = new MutationObserver(() => {
-      if (!overlay.isConnected) {
-        done();
-      }
-    });
-    removalObserver.observe(overlay.parentElement ?? document.body, {
-      childList: true,
-      subtree: true,
-    });
-  });
-}
-
-async function waitActionProgress(overlay: HTMLElement) {
-  if (!overlay.classList.contains(C.ActionFeedback.progress)) {
-    return;
-  }
-  await new Promise<void>(resolve => {
-    const mutationObserver = new MutationObserver(() => {
-      if (!overlay.classList.contains(C.ActionFeedback.progress)) {
-        mutationObserver.disconnect();
-        resolve();
-      }
-    });
-    mutationObserver.observe(overlay, { attributes: true });
-  });
-}

--- a/lib/contract-actions.ts
+++ b/lib/contract-actions.ts
@@ -9,6 +9,7 @@ import { openMobileBuffer, closeMobileBuffer } from './mobile-buffer-navigator';
 import { waitActionFeedback } from './act/action-feedback';
 import { setupActGlobals } from './act/globals-setup';
 import { clickElement } from './act/_compat';
+import { C } from './act/prun-css';
 import { useSettingsStore } from '../stores/settings';
 import { useGameState } from '../stores/gameState';
 
@@ -22,7 +23,30 @@ export type ContractActionTarget =
    *  available-ordinal picks the wrong row whenever the two sets differ. */
   | { kind: 'fulfill'; conditionNumber: number };
 
-export type ContractActionResult = { ok: true } | { ok: false; error: string };
+export type ContractActionResult =
+  | { ok: true }
+  | {
+      ok: false;
+      error: string;
+      /** The target button exists but APEX renders it disabled — the game
+       *  gates on state the WS data doesn't expose (shipment arrival, funds).
+       *  The view mirrors the disabled state instead of showing the error. */
+      disabledInApex?: true;
+    };
+
+/**
+ * APEX marks a gated command button with a Button__disabled class, NOT the
+ * disabled attribute (device-captured 2026-08-13; the attribute is checked
+ * anyway in case other buffers differ). Clicking one is a silent no-op — no
+ * feedback overlay ever appears — so it must be detected before clicking.
+ */
+export function isApexButtonDisabled(button: HTMLElement): boolean {
+  if (button instanceof HTMLButtonElement && button.disabled) return true;
+  const parsed = (C.Button as Record<string, string> | undefined)?.disabled;
+  if (parsed && button.classList.contains(parsed)) return true;
+  // Stylesheet parsing unavailable: the BEM prefix is stable, the hash isn't.
+  return Array.from(button.classList).some((cls) => cls.startsWith('Button__disabled'));
+}
 
 // APEX renders CSS text-transform: uppercase, so visible label case is
 // meaningless — match textContent case-insensitively (CLAUDE.md gotcha).
@@ -108,6 +132,9 @@ export async function runContractAction(
               ? 'No fulfill button found — this condition type may need APEX (see #73)'
               : `No ${target.kind} button found in the contract buffer`,
         };
+      }
+      if (isApexButtonDisabled(button)) {
+        return { ok: false, disabledInApex: true, error: 'Not yet enabled in APEX' };
       }
       await clickElement(button);
       const autoConfirm = useSettingsStore.getState().autoConfirm;

--- a/lib/contract-actions.ts
+++ b/lib/contract-actions.ts
@@ -15,11 +15,12 @@ import { useGameState } from '../stores/gameState';
 export type ContractActionTarget =
   | { kind: 'accept' }
   | { kind: 'reject' }
-  /** conditionIndex is the ordinal among AVAILABLE (fulfillable) conditions
-   *  in contract order — APEX renders a button per fulfillable row, so the
-   *  Nth matched button belongs to the Nth available condition, not to the
-   *  condition's raw index. */
-  | { kind: 'fulfill'; conditionIndex: number };
+  /** conditionNumber is the game-displayed condition number (condition.index
+   *  + 1), matched against the CONT buffer row's Index cell ("#3"). Device
+   *  finding (2026-08-13): APEX renders a — possibly disabled — button on
+   *  EVERY self non-fulfilled row, so counting matched buttons by APXM's
+   *  available-ordinal picks the wrong row whenever the two sets differ. */
+  | { kind: 'fulfill'; conditionNumber: number };
 
 export type ContractActionResult = { ok: true } | { ok: false; error: string };
 
@@ -35,29 +36,43 @@ const TARGET_LABELS: Record<'accept' | 'reject' | 'fulfill', string[]> = {
   fulfill: ['fulfill', 'fulfil', 'pay', 'provide'],
 };
 
+function labelMatches(el: HTMLElement, labels: string[]): boolean {
+  const text = el.textContent?.trim().toLowerCase() ?? '';
+  return labels.some((label) => text === label);
+}
+
 /**
- * Finds the APEX button for a target inside the opened CONT buffer. For
- * fulfill, the available-ordinal picks among multiple matches (see
- * ContractActionTarget). Exported for tests.
+ * Finds the APEX button for a target inside the opened CONT buffer.
+ * Contract-level accept/reject match by label alone. Fulfill is addressed by
+ * ROW: the conditions table's first cell carries the game-displayed condition
+ * number ("#3"), so the button is taken from that row — never by counting
+ * matches, which misaligns against disabled rows (see ContractActionTarget).
+ * Falls back to a single unambiguous label match if the table shape ever
+ * changes. Exported for tests.
  */
 export function findContractActionButton(
   root: HTMLElement,
   target: ContractActionTarget
 ): HTMLElement | undefined {
   const labels = TARGET_LABELS[target.kind];
-  const matches: HTMLElement[] = [];
-  for (const el of Array.from(root.getElementsByTagName('button'))) {
-    const text = el.textContent?.trim().toLowerCase() ?? '';
-    if (labels.some((label) => text === label)) {
-      matches.push(el);
-    }
-  }
+  const matches = Array.from(root.getElementsByTagName('button')).filter((el) =>
+    labelMatches(el, labels)
+  );
   if (target.kind !== 'fulfill') {
     return matches[0];
   }
-  // Multiple fulfillable conditions render multiple buttons; a single match
-  // is used regardless of index (the other conditions render none).
-  return matches.length === 1 ? matches[0] : matches[target.conditionIndex];
+
+  const rowLabel = `#${target.conditionNumber}`;
+  for (const row of Array.from(root.getElementsByTagName('tr'))) {
+    const indexCell = row.getElementsByTagName('td')[0];
+    if (indexCell?.textContent?.trim() !== rowLabel) continue;
+    return Array.from(row.getElementsByTagName('button')).find((el) =>
+      labelMatches(el, labels)
+    );
+  }
+  // Row addressing found nothing — only trust a label match if it's the sole
+  // candidate; guessing among several risks committing the wrong condition.
+  return matches.length === 1 ? matches[0] : undefined;
 }
 
 // One driven action at a time — a second tap while a buffer is being driven

--- a/lib/contract-actions.ts
+++ b/lib/contract-actions.ts
@@ -16,6 +16,7 @@ import { useGameState } from '../stores/gameState';
 export type ContractActionTarget =
   | { kind: 'accept' }
   | { kind: 'reject' }
+  | { kind: 'terminate' }
   /** conditionNumber is the game-displayed condition number (condition.index
    *  + 1), matched against the CONT buffer row's Index cell ("#3"). Device
    *  finding (2026-08-13): APEX renders a — possibly disabled — button on
@@ -54,9 +55,10 @@ export function isApexButtonDisabled(button: HTMLElement): boolean {
 // the CONT buffer's DOM (rPrun never drives it), so the candidate set grows
 // from device testing. Condition types whose button opens a form instead of
 // committing are documented as not-one-tappable, not special-cased here.
-const TARGET_LABELS: Record<'accept' | 'reject' | 'fulfill', string[]> = {
+const TARGET_LABELS: Record<'accept' | 'reject' | 'terminate' | 'fulfill', string[]> = {
   accept: ['accept'],
   reject: ['reject', 'decline'],
+  terminate: ['request termination'],
   fulfill: ['fulfill', 'fulfil', 'pay', 'provide'],
 };
 

--- a/lib/contract-actions.ts
+++ b/lib/contract-actions.ts
@@ -1,0 +1,113 @@
+// One-tap contract actions (#73): the user taps ACCEPT / REJECT / FULFILL in
+// APXM's contract sheet, and APXM drives the CONT buffer off-screen —
+// open buffer, click the matching APEX button, observe the feedback overlay,
+// close and restore. The user's tap IS the commit (one tap, one action); if
+// APEX pops its confirmation dialog and settings.autoConfirm is off, the
+// manual-confirm visibility mode hands them the dialog itself.
+
+import { openMobileBuffer, closeMobileBuffer } from './mobile-buffer-navigator';
+import { waitActionFeedback } from './act/action-feedback';
+import { setupActGlobals } from './act/globals-setup';
+import { clickElement } from './act/_compat';
+import { useSettingsStore } from '../stores/settings';
+import { useGameState } from '../stores/gameState';
+
+export type ContractActionTarget =
+  | { kind: 'accept' }
+  | { kind: 'reject' }
+  /** conditionIndex is the ordinal among AVAILABLE (fulfillable) conditions
+   *  in contract order — APEX renders a button per fulfillable row, so the
+   *  Nth matched button belongs to the Nth available condition, not to the
+   *  condition's raw index. */
+  | { kind: 'fulfill'; conditionIndex: number };
+
+export type ContractActionResult = { ok: true } | { ok: false; error: string };
+
+// APEX renders CSS text-transform: uppercase, so visible label case is
+// meaningless — match textContent case-insensitively (CLAUDE.md gotcha).
+// FULFILL labels are the discovery surface of this feature: nobody documents
+// the CONT buffer's DOM (rPrun never drives it), so the candidate set grows
+// from device testing. Condition types whose button opens a form instead of
+// committing are documented as not-one-tappable, not special-cased here.
+const TARGET_LABELS: Record<'accept' | 'reject' | 'fulfill', string[]> = {
+  accept: ['accept'],
+  reject: ['reject', 'decline'],
+  fulfill: ['fulfill', 'fulfil', 'pay', 'provide'],
+};
+
+/**
+ * Finds the APEX button for a target inside the opened CONT buffer. For
+ * fulfill, the available-ordinal picks among multiple matches (see
+ * ContractActionTarget). Exported for tests.
+ */
+export function findContractActionButton(
+  root: HTMLElement,
+  target: ContractActionTarget
+): HTMLElement | undefined {
+  const labels = TARGET_LABELS[target.kind];
+  const matches: HTMLElement[] = [];
+  for (const el of Array.from(root.getElementsByTagName('button'))) {
+    const text = el.textContent?.trim().toLowerCase() ?? '';
+    if (labels.some((label) => text === label)) {
+      matches.push(el);
+    }
+  }
+  if (target.kind !== 'fulfill') {
+    return matches[0];
+  }
+  // Multiple fulfillable conditions render multiple buttons; a single match
+  // is used regardless of index (the other conditions render none).
+  return matches.length === 1 ? matches[0] : matches[target.conditionIndex];
+}
+
+// One driven action at a time — a second tap while a buffer is being driven
+// would fight over #container. Module-level like the MTRA buffer cache.
+let inFlight = false;
+
+export function isContractActionInFlight(): boolean {
+  return inFlight;
+}
+
+export async function runContractAction(
+  localId: string,
+  target: ContractActionTarget
+): Promise<ContractActionResult> {
+  if (inFlight) {
+    return { ok: false, error: 'Another action is already running' };
+  }
+  inFlight = true;
+  try {
+    setupActGlobals();
+    const opened = await openMobileBuffer(`CONT ${localId}`);
+    const anchor = document.getElementById('container');
+    if (!opened || !anchor) {
+      return { ok: false, error: `Failed to open CONT ${localId}` };
+    }
+    try {
+      const button = findContractActionButton(anchor, target);
+      if (!button) {
+        return {
+          ok: false,
+          error:
+            target.kind === 'fulfill'
+              ? 'No fulfill button found — this condition type may need APEX (see #73)'
+              : `No ${target.kind} button found in the contract buffer`,
+        };
+      }
+      await clickElement(button);
+      const autoConfirm = useSettingsStore.getState().autoConfirm;
+      const error = await waitActionFeedback({ anchor }, autoConfirm, (pending) =>
+        useGameState.getState().setActConfirmPending(pending)
+      );
+      if (error) {
+        return { ok: false, error };
+      }
+      return { ok: true };
+    } finally {
+      // Always restore APEX — even on failure the buffer must not stay parked.
+      await closeMobileBuffer();
+    }
+  } finally {
+    inFlight = false;
+  }
+}

--- a/stores/__tests__/gameState.test.ts
+++ b/stores/__tests__/gameState.test.ts
@@ -38,6 +38,19 @@ describe('gameState store', () => {
     it('starts with no drill-down sheet open', () => {
       expect(useGameState.getState().detailView).toBeNull();
     });
+
+    it('starts with no manual-confirm window pending', () => {
+      expect(useGameState.getState().actConfirmPending).toBe(false);
+    });
+  });
+
+  describe('setActConfirmPending', () => {
+    it('round-trips the manual-confirm window flag', () => {
+      useGameState.getState().setActConfirmPending(true);
+      expect(useGameState.getState().actConfirmPending).toBe(true);
+      useGameState.getState().setActConfirmPending(false);
+      expect(useGameState.getState().actConfirmPending).toBe(false);
+    });
   });
 
   describe('setOverlayVisible', () => {

--- a/stores/gameState.ts
+++ b/stores/gameState.ts
@@ -79,11 +79,18 @@ interface GameState {
   contractFilters: ReadonlySet<ContractFilter>;
   // The active drill-down sheet, or null when none is open. Session-scoped.
   detailView: DetailView | null;
+  /** True while a driven APEX action waits for the user's CONFIRM tap in
+   *  APEX's own dialog. AppShell hides the (opaque) shell and drops the
+   *  shadow host's background so the dialog is visible and tappable; a slim
+   *  ConfirmBar is the only APXM chrome. Set from the action-feedback
+   *  onManualConfirm signal. Session-scoped. */
+  actConfirmPending: boolean;
   setOverlayVisible: (visible: boolean) => void;
   setDebugMode: (debug: boolean) => void;
   setApexVisible: (visible: boolean) => void;
   setActiveTab: (tab: TabId) => void;
   setDetailView: (view: DetailView | null) => void;
+  setActConfirmPending: (pending: boolean) => void;
   toggleBurnFilter: (filter: BurnFilter) => void;
   toggleFleetFilter: (filter: FleetFilter) => void;
   toggleContractFilter: (filter: ContractFilter) => void;
@@ -99,11 +106,13 @@ export const useGameState = create<GameState>((set) => ({
   // Contracts default to ACTIVE — fulfilled contracts are history
   contractFilters: new Set<ContractFilter>(['active']),
   detailView: null,
+  actConfirmPending: false,
   setOverlayVisible: (overlayVisible) => set({ overlayVisible }),
   setDebugMode: (debugMode) => set({ debugMode }),
   setApexVisible: (apexVisible) => set({ apexVisible }),
   setActiveTab: (activeTab) => set({ activeTab }),
   setDetailView: (detailView) => set({ detailView }),
+  setActConfirmPending: (actConfirmPending) => set({ actConfirmPending }),
   toggleBurnFilter: (filter) =>
     set((state) => ({
       burnFilters: toggleFilterSelection(state.burnFilters, filter, individualBurnFilters),


### PR DESCRIPTION
## Summary

The centerpiece of the action-passthrough wave: the contract sheet's deliberately-withheld actions ship, done **inside APXM with no switch to APEX** per the #25 direction ruling. Your tap is the commit — one tap, one action, nothing unattended. Three commits:

**1. `refactor(act)`: extract the action-feedback observer.** `waitActionFeedback`/`waitConfirmationResolved`/`waitActionProgress` move from the step machine to `lib/act/action-feedback.ts` so one implementation serves the ACT engine and one-shot actions. New optional `onManualConfirm(pending)` callback fires around the manual-confirm window (balanced even on cancel/overlay removal) — the visibility signal the next commit consumes, and the one the future ACT views (#25 Phase D) will reuse. Step-machine behaviour unchanged; existing gate tests pass untouched.

**2. `feat(shell)`: manual-confirm visibility mode.** Design-phase discovery: with `autoConfirm` off, APEX's confirmation dialog was un-hidden *underneath* the opaque APXM shadow host — physically untappable. Now `gameState.actConfirmPending` hides the shell via CSS (stays mounted), shows a slim `ConfirmBar` ("Confirm or cancel in APEX below"), and `:host(.act-confirm)` drops **only the host background** — never the height, which APEX's layout listeners read as navigation mid-drive (CLAUDE.md gotcha). Base `pointer-events: none` passes taps through to APEX's dialog. No APXM-side cancel button (deviation from the plan sketch): APEX's own dialog is fully visible/tappable and the observer already handles both exits.

**3. `feat(contracts)`: the actions.** `runContractAction(localId, target)`: open `CONT <localId>` off-screen → click APEX's button (case-insensitive text match — visible case is CSS `text-transform`) → observe feedback → always restore APEX. ACCEPT/REJECT render when `acceptance === 'awaiting-mine'`; FULFILL per `available` condition, addressed by **ordinal among available conditions** (APEX renders one button per fulfillable row; raw indexes would misalign past fulfilled/partner rows). One action in flight at a time; APEX's error text surfaces inline; success needs no refresh (the `CONTRACTS_CONTRACT` delta updates the store).

## Known device-discovery items (#73)

Nobody drives the CONT buffer — not rPrun, not the fork — so these need the dev-build session before release:
- Actual button labels (accept/reject assumed; fulfill candidates: fulfill/pay/provide).
- Whether contract actions pop the confirmation overlay at all (the mechanism handles both).
- ConfirmBar placement vs APEX's dialog (top chosen; swap to bottom if it covers).
- Verify APEX's stack does NOT navigate when `act-confirm` toggles.

## Testing

- 596 tests pass (+16 on this branch): action-feedback signal window semantics (fires/never-fires/balanced-on-cancel), gameState flag, matcher (case-insensitivity, fulfill ordinal, synonyms), runner (success/error/missing-button/confirm-window/in-flight guard/open-failure — buffer always restored).
- Mutation-verified: removing the in-flight guard fails its test; dropping case-folding fails 7.
- `npx tsc --noEmit` clean; Chrome + Firefox builds green.

Closes #73. Part of #25's direction; the ACT views inherit `onManualConfirm` + `act-confirm` + `ConfirmBar` wholesale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)