### PR TITLE
fix(alerts): show only unread notifications in the Alerts panel

### DIFF
--- a/components/status/AlertsPanel.tsx
+++ b/components/status/AlertsPanel.tsx
@@ -4,8 +4,8 @@ import { useAlertsStore } from '../../stores/entities';
 import { formatAlert } from '../../lib/format-alert';
 import { formatRelativeTime } from '../../lib/format-time';
 
-// The NOTS list can run long; cap the panel and say so rather than scroll
-// forever — the full history lives in APEX.
+// Unread can still run long (the login snapshot arrives before APEX marks
+// anything read); cap the panel and say so rather than scroll forever.
 const MAX_ROWS = 50;
 
 /**
@@ -14,19 +14,25 @@ const MAX_ROWS = 50;
  * are visible without switching to APEX. Read state is server-driven and
  * display-only — marking read would require sending a message, which APXM
  * never does.
+ *
+ * Unread only (for now): the login snapshot carries the full NOTS history,
+ * which is several screens of already-read noise on first load. Read alerts
+ * live in APEX's NOTS buffer; this panel is the "what needs my attention"
+ * view. Revisit if a history view is ever wanted here.
  */
 export function AlertsPanel({ handle }: { handle?: ReactNode }) {
   const [collapsed, setCollapsed] = useState(true);
   const fetched = useAlertsStore((s) => s.fetched);
   const entities = useAlertsStore((s) => s.entities);
 
-  const alerts = useMemo(
+  const unreadAlerts = useMemo(
     () =>
-      Array.from(entities.values()).sort((a, b) => b.time.timestamp - a.time.timestamp),
+      Array.from(entities.values())
+        .filter((a) => !a.read)
+        .sort((a, b) => b.time.timestamp - a.time.timestamp),
     [entities]
   );
-  const unread = useMemo(() => alerts.filter((a) => !a.read).length, [alerts]);
-  const rows = alerts.slice(0, MAX_ROWS);
+  const rows = unreadAlerts.slice(0, MAX_ROWS);
 
   return (
     <Panel
@@ -35,13 +41,13 @@ export function AlertsPanel({ handle }: { handle?: ReactNode }) {
       collapsible
       collapsed={collapsed}
       onToggleCollapse={() => setCollapsed((c) => !c)}
-      summary={unread > 0 ? `${unread} unread` : `${alerts.length}`}
+      summary={`${unreadAlerts.length} unread`}
       handle={handle}
     >
       {!fetched ? (
         <p className="text-xs text-apxm-muted">Waiting for game data...</p>
-      ) : alerts.length === 0 ? (
-        <p className="text-xs text-apxm-muted">No notifications</p>
+      ) : unreadAlerts.length === 0 ? (
+        <p className="text-xs text-apxm-muted">No unread notifications</p>
       ) : (
         <div className="space-y-1">
           {rows.map((alert) => {
@@ -51,24 +57,16 @@ export function AlertsPanel({ handle }: { handle?: ReactNode }) {
                 <span className="font-mono text-[10px] uppercase text-apxm-text/50 w-16 shrink-0">
                   {category}
                 </span>
-                <span
-                  className={`flex-1 min-w-0 ${
-                    alert.read ? 'text-apxm-muted' : 'text-apxm-text'
-                  }`}
-                >
-                  {/* Unread also gets a marker — colour alone can't carry state */}
-                  {!alert.read && <span className="text-prun-yellow mr-1">●</span>}
-                  {text}
-                </span>
+                <span className="flex-1 min-w-0 text-apxm-text">{text}</span>
                 <span className="font-mono text-[10px] text-apxm-text/50 shrink-0">
                   {formatRelativeTime(alert.time.timestamp)}
                 </span>
               </div>
             );
           })}
-          {alerts.length > MAX_ROWS && (
+          {unreadAlerts.length > MAX_ROWS && (
             <p className="text-[10px] text-apxm-muted pt-1">
-              +{alerts.length - MAX_ROWS} older — see NOTS in APEX
+              +{unreadAlerts.length - MAX_ROWS} more unread — see NOTS in APEX
             </p>
           )}
         </div>

--- a/components/status/__tests__/AlertsPanel.test.tsx
+++ b/components/status/__tests__/AlertsPanel.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { AlertsPanel } from '../AlertsPanel';
+import { useAlertsStore } from '../../../stores/entities';
+import { createTestAlert } from '../../../__tests__/fixtures/factories';
+
+// Unread-only panel: the login snapshot carries the full NOTS history, so an
+// unfiltered panel opens on several screens of already-read noise. Read
+// alerts belong to APEX's NOTS buffer.
+//
+// Client-rendered (createRoot + act), NOT renderToString: zustand v4 pins
+// server renders to the store's creation-time state via getServerState, so
+// SSR output never reflects test mutations of a store.
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+function renderPanel(): string {
+  act(() => {
+    root.render(<AlertsPanel />);
+  });
+  return container.innerHTML;
+}
+
+beforeEach(() => {
+  useAlertsStore.getState().clear();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe('AlertsPanel (unread only)', () => {
+  it('shows unread alerts and hides read ones', () => {
+    useAlertsStore.getState().setAll([
+      createTestAlert({ id: 'a-unread', type: 'PRODUCTION_ORDER_FINISHED', read: false }),
+      createTestAlert({ id: 'a-read', type: 'SHIP_FLIGHT_ENDED', read: true }),
+    ]);
+    useAlertsStore.getState().setFetched('websocket');
+
+    const html = renderPanel();
+    expect(html).toContain('1 unread');
+    // The read alert's category must not render (SHIP alerts are the only
+    // fleet-category row in this fixture set).
+    expect(html).toContain('production');
+    expect(html).not.toContain('fleet');
+  });
+
+  it('reads "No unread notifications" when everything is read', () => {
+    useAlertsStore.getState().setAll([createTestAlert({ id: 'a-read', read: true })]);
+    useAlertsStore.getState().setFetched('websocket');
+
+    const html = renderPanel();
+    expect(html).toContain('0 unread');
+    expect(html).toContain('No unread notifications');
+  });
+
+  it('caps rows at 50 and counts only unread in the overflow line', () => {
+    const alerts = Array.from({ length: 55 }, (_, i) =>
+      createTestAlert({ id: `a-${i}`, read: false })
+    ).concat(Array.from({ length: 20 }, (_, i) => createTestAlert({ id: `r-${i}`, read: true })));
+    useAlertsStore.getState().setAll(alerts);
+    useAlertsStore.getState().setFetched('websocket');
+
+    const html = renderPanel();
+    expect(html).toContain('55 unread');
+    // 55 unread − 50 shown = 5; the 20 read alerts must not inflate this.
+    expect(html).toContain('+5 more unread');
+  });
+});


### PR DESCRIPTION
Device-test finding on the freshly merged #72: the login snapshot carries the full NOTS history, so first load showed several screens of already-read alerts; after visiting NOTS in APEX (server marks read) it collapsed to the useful unread view. Make unread-only the panel's behaviour — read alerts live in APEX's NOTS buffer.

- Filter to `!read`; summary always `N unread`; empty state "No unread notifications"
- 50-row cap and the "+N more unread — see NOTS in APEX" overflow now count unread only
- Per-row read styling + unread dot removed (single-state list)
- New component-level tests (createRoot+act — renderToString can't see store mutations under zustand v4's getServerState), mutation-verified

624 tests green, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)