### PR TITLE
feat(contracts): show condition locations in the contract sheet

### DIFF
--- a/components/views/hooks/__tests__/useContractDetails.test.ts
+++ b/components/views/hooks/__tests__/useContractDetails.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { buildContractDetail, assembleContractDetails } from '../useContractDetails';
-import { createTestContract, createContractCondition } from '../../../../__tests__/fixtures/factories';
+import { createTestContract, createContractCondition, createAddress } from '../../../../__tests__/fixtures/factories';
 import type { PrunApi } from '../../../../types/prun-api';
 
 /**
@@ -154,6 +154,62 @@ describe('buildContractDetail — dependency-aware condition flags', () => {
     // neither available (status !== PENDING) nor blocked (no unfulfilled dep).
     expect(cond.available).toBe(false);
     expect(cond.blocked).toBe(false);
+  });
+});
+
+describe('buildContractDetail — condition locations (device finding 2026-08-13)', () => {
+  // The game's CONT text always names where a condition happens; an accept
+  // decision is impossible without it. destination (deliveries) and address
+  // (provision/pickup) both surface as a destination part.
+  it('a provision condition surfaces its address as a destination part', () => {
+    const contract = acceptedContract([
+      selfCondition({
+        id: 'c1',
+        index: 0,
+        type: 'PROVISION',
+        dependencies: [],
+        address: createAddress({ planetName: 'Antares IV - Life' }),
+      }),
+    ]);
+
+    const [cond] = buildContractDetail(contract).conditions;
+    expect(cond.descriptionParts).toContainEqual({
+      type: 'destination',
+      value: 'Antares IV - Life',
+    });
+    expect(cond.description).toContain('→ Antares IV - Life');
+  });
+
+  it('a delivery condition still surfaces its destination', () => {
+    const contract = acceptedContract([
+      selfCondition({
+        id: 'c1',
+        index: 0,
+        type: 'DELIVERY',
+        dependencies: [],
+        destination: createAddress({ planetName: 'Promitor' }),
+      }),
+    ]);
+
+    const [cond] = buildContractDetail(contract).conditions;
+    expect(cond.descriptionParts).toContainEqual({ type: 'destination', value: 'Promitor' });
+  });
+
+  it('a payment condition with no address renders without a location', () => {
+    const contract = acceptedContract([
+      selfCondition({
+        id: 'c1',
+        index: 0,
+        type: 'PAYMENT',
+        dependencies: [],
+        quantity: null,
+        amount: { amount: 1000, currency: 'AIC' },
+      }),
+    ]);
+
+    const [cond] = buildContractDetail(contract).conditions;
+    expect(cond.descriptionParts.some((p) => p.type === 'destination')).toBe(false);
+    expect(cond.description).not.toContain('→');
   });
 });
 

--- a/components/views/hooks/useContractDetails.ts
+++ b/components/views/hooks/useContractDetails.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 import { useContractsStore } from '../../../stores/entities/contracts';
+import { getEntityDisplayName } from '../../../lib/address';
 import type { PrunApi } from '../../../types/prun-api';
 
 import type { ContractFilter } from '../../../stores/gameState';
@@ -127,21 +128,41 @@ interface ConditionDescriptionResult {
 }
 
 /**
+ * The place a condition happens: destination for deliveries, address for
+ * provision/pickup-style conditions. The game's CONT text always names it
+ * ("@ Antares IV - Life") and an accept decision is impossible without it,
+ * so every condition carrying one displays it (device finding 2026-08-13).
+ */
+function conditionLocation(condition: PrunApi.ContractCondition): string | null {
+  const address = condition.destination ?? condition.address;
+  if (!address) return null;
+  return getEntityDisplayName(address) || null;
+}
+
+/**
  * Builds a description string and structured parts for a condition.
  */
 function buildConditionDescription(condition: PrunApi.ContractCondition): ConditionDescriptionResult {
   const type = formatConditionType(condition.type);
   const parts: ConditionPart[] = [];
+  const location = conditionLocation(condition);
 
-  // Payment condition
-  if (condition.amount) {
-    const description = `${type} ${condition.amount.amount.toLocaleString()} ${condition.amount.currency}`;
-    parts.push({ type: 'text', value: type });
-    parts.push({ type: 'amount', value: `${condition.amount.amount.toLocaleString()} ${condition.amount.currency}` });
+  function withLocation(description: string): ConditionDescriptionResult {
+    if (location) {
+      parts.push({ type: 'destination', value: location });
+      return { description: `${description} → ${location}`, parts };
+    }
     return { description, parts };
   }
 
-  // Delivery condition with material
+  // Payment condition
+  if (condition.amount) {
+    parts.push({ type: 'text', value: type });
+    parts.push({ type: 'amount', value: `${condition.amount.amount.toLocaleString()} ${condition.amount.currency}` });
+    return withLocation(`${type} ${condition.amount.amount.toLocaleString()} ${condition.amount.currency}`);
+  }
+
+  // Material condition (delivery, provision, pickup, shipment)
   if (condition.quantity) {
     const ticker = condition.quantity.material.ticker;
     const category = condition.quantity.material.category;
@@ -150,24 +171,11 @@ function buildConditionDescription(condition: PrunApi.ContractCondition): Condit
     parts.push({ type: 'text', value: type });
     parts.push({ type: 'material', value: ticker, category });
     parts.push({ type: 'amount', value: String(amount) });
-
-    let dest = '';
-    if (condition.destination) {
-      for (const line of condition.destination.lines) {
-        if ((line.type === 'PLANET' || line.type === 'STATION') && line.entity) {
-          dest = line.entity.name || line.entity.naturalId;
-          parts.push({ type: 'destination', value: dest });
-          break;
-        }
-      }
-    }
-
-    const description = `${type} [${ticker}] ${amount}${dest ? ` → ${dest}` : ''}`;
-    return { description, parts };
+    return withLocation(`${type} [${ticker}] ${amount}`);
   }
 
   parts.push({ type: 'text', value: type });
-  return { description: type, parts };
+  return withLocation(type);
 }
 
 /**


### PR DESCRIPTION
Device-test finding: an awaiting-acceptance contract's sheet showed "Provision H2O 158" with no idea *where* — the game's CONT text always names the place, and the accept decision hinges on it. `condition.destination` (deliveries) and `condition.address` (provision/pickup) now both surface as a destination part through the established `getEntityDisplayName` display rule, for every condition shape.

627 tests green (+3), tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)